### PR TITLE
Add MapStructure and MapTable methods

### DIFF
--- a/src/YaNco.Core/FunctionalDataContainerExtensions.cs
+++ b/src/YaNco.Core/FunctionalDataContainerExtensions.cs
@@ -43,5 +43,11 @@ namespace Dbosoft.YaNco
                     ).Traverse(l => l).Map(_ => dc))));
 
         }
+
+        static public Either<RfcErrorInfo, IEnumerable<TResult>> MapStructure<TResult>(this ITable table, Func<IStructure,Either<RfcErrorInfo, TResult>> mapperFunc)
+        {
+            return table.Rows.Map(mapperFunc).Traverse(l=>l);
+        }
+
     }
 }

--- a/src/YaNco.Core/FunctionalDataContainerExtensions.cs
+++ b/src/YaNco.Core/FunctionalDataContainerExtensions.cs
@@ -49,5 +49,16 @@ namespace Dbosoft.YaNco
             return table.Rows.Map(mapperFunc).Traverse(l=>l);
         }
 
+        static public Either<RfcErrorInfo, IEnumerable<TResult>> MapTable<TResult>(this IDataContainer self, string tableName, Func<IStructure, Either<RfcErrorInfo, TResult>> mapperFunc)
+        {
+            return self.GetTable(tableName).Bind(t => t.MapStructure(mapperFunc));
+        }
+
+        static public Either<RfcErrorInfo, TResult> MapStructure<TResult>(this IDataContainer self, string structureName, Func<IStructure, Either<RfcErrorInfo, TResult>> mapperFunc)
+        {
+            return self.GetStructure(structureName).Bind(mapperFunc);
+
+        }
+
     }
 }

--- a/src/YaNco.Core/FunctionalFunctionsExtensions.cs
+++ b/src/YaNco.Core/FunctionalFunctionsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using LanguageExt;
@@ -93,6 +94,22 @@ namespace Dbosoft.YaNco
         public static Task<Either<RfcErrorInfo, T>> GetField<T>(this Task<Either<RfcErrorInfo, IFunction>> self, string name)
         {
             return self.BindAsync(s => s.GetField<T>(name));
+        }
+
+        static public Task<Either<RfcErrorInfo, IEnumerable<TResult>>> MapTable<TResult>(this Task<Either<RfcErrorInfo, IFunction>> self, string tableName, Func<IStructure, Either<RfcErrorInfo, TResult>> mapperFunc)
+        {
+            return self
+                .BindAsync(f => f.GetTable(tableName))
+                .BindAsync(t => t.MapStructure(mapperFunc));
+
+        }
+
+        static public Task<Either<RfcErrorInfo, TResult>> MapStructure<TResult>(this Task<Either<RfcErrorInfo, IFunction>> self, string structureName, Func<IStructure, Either<RfcErrorInfo, TResult>> mapperFunc)
+        {
+            return self
+                .BindAsync(f => f.GetStructure(structureName))
+                .BindAsync(mapperFunc);
+
         }
     }
 }

--- a/src/YaNco.Core/FunctionalFunctionsExtensions.cs
+++ b/src/YaNco.Core/FunctionalFunctionsExtensions.cs
@@ -127,18 +127,12 @@ namespace Dbosoft.YaNco
 
         static public EitherAsync<RfcErrorInfo, IEnumerable<TResult>> MapTable<TResult>(this Task<Either<RfcErrorInfo, IFunction>> self, string tableName, Func<IStructure, Either<RfcErrorInfo, TResult>> mapperFunc)
         {
-            return self
-                .BindAsync(f => f.GetTable(tableName))
-                .BindAsync(t => t.MapStructure(mapperFunc)).ToAsync();
-
+            return self.BindAsync(f => f.MapTable(tableName, mapperFunc)).ToAsync();
         }
 
         static public EitherAsync<RfcErrorInfo, TResult> MapStructure<TResult>(this Task<Either<RfcErrorInfo, IFunction>> self, string structureName, Func<IStructure, Either<RfcErrorInfo, TResult>> mapperFunc)
         {
-            return self
-                .BindAsync(f => f.GetStructure(structureName))
-                .BindAsync(mapperFunc).ToAsync();
-
+            return self.BindAsync(f => f.MapStructure(structureName, mapperFunc)).ToAsync();
         }
     }
 }

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -68,54 +68,6 @@ namespace SAPSystemTests
                 long totalTest1 = 0;
                 long totalTest2 = 0;
 
-                using (var context = new RfcContext(ConnFunc))
-                {
-                    await context.CallFunction("BAPI_COMPANYCODE_GETDETAIL",
-                            Input: f => f
-                                .SetField("COMPANYCODEID", "1000"),
-                            Output: func => func.MapStructure("COMPANYCODE_DETAIL", structure =>
-                                from name in structure.GetField<string>("COMP_NAME")
-                                select name
-                            )
-                        )
-
-                        .ToAsync().Match(r => Console.WriteLine($"Result: {r}"),
-                            l => Console.WriteLine($"Error: {l.Message}"));
-
-
-                    await context.CallFunction("BAPI_COMPANYCODE_GETLIST",
-                            Output: func => 
-                                
-                                from tab1 in func.MapTable("COMPANYCODE_LIST",s =>
-                                    from code in s.GetField<string>("COMP_CODE")
-                                    from name in s.GetField<string>("COMP_NAME")
-                                    select (code, name))
-
-                                from struct2 in func.MapStructure("COMPANYCODE_LIST", s =>
-                                    from code in s.GetField<string>("COMP_CODE")
-                                    from name in s.GetField<string>("COMP_NAME")
-                                    select (code, name))
-
-                                from struct3 in func.MapStructure("COMPANYCODE_LIST", s =>
-                                    from code in s.GetField<string>("COMP_CODE")
-                                    from nameInSubstruct in s.MapStructure("SUB1", sub1 =>
-                                        from name in sub1.GetField<string>("COMP_NAME")
-                                        select name)
-                                    select (code, nameInSubstruct))
-                                
-
-                                select (tab1, struct2))
-                        .ToAsync().Match(
-                            r =>
-                            {
-                                foreach (var (code, name) in r)
-                                {
-                                    Console.WriteLine($"{code}\t{name}");
-                                }
-                            },
-                            l => Console.WriteLine($"Error: {l.Message}"));
-                }
-
                 for (var run = 0; run < repeats; run++)
                 {
                     Console.WriteLine($"starting Test Run {run+1} of {repeats}\tTest 01");

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -68,6 +68,54 @@ namespace SAPSystemTests
                 long totalTest1 = 0;
                 long totalTest2 = 0;
 
+                using (var context = new RfcContext(ConnFunc))
+                {
+                    await context.CallFunction("BAPI_COMPANYCODE_GETDETAIL",
+                            Input: f => f
+                                .SetField("COMPANYCODEID", "1000"),
+                            Output: func => func.MapStructure("COMPANYCODE_DETAIL", structure =>
+                                from name in structure.GetField<string>("COMP_NAME")
+                                select name
+                            )
+                        )
+
+                        .ToAsync().Match(r => Console.WriteLine($"Result: {r}"),
+                            l => Console.WriteLine($"Error: {l.Message}"));
+
+
+                    await context.CallFunction("BAPI_COMPANYCODE_GETLIST",
+                            Output: func => 
+                                
+                                from tab1 in func.MapTable("COMPANYCODE_LIST",s =>
+                                    from code in s.GetField<string>("COMP_CODE")
+                                    from name in s.GetField<string>("COMP_NAME")
+                                    select (code, name))
+
+                                from struct2 in func.MapStructure("COMPANYCODE_LIST", s =>
+                                    from code in s.GetField<string>("COMP_CODE")
+                                    from name in s.GetField<string>("COMP_NAME")
+                                    select (code, name))
+
+                                from struct3 in func.MapStructure("COMPANYCODE_LIST", s =>
+                                    from code in s.GetField<string>("COMP_CODE")
+                                    from nameInSubstruct in s.MapStructure("SUB1", sub1 =>
+                                        from name in sub1.GetField<string>("COMP_NAME")
+                                        select name)
+                                    select (code, nameInSubstruct))
+                                
+
+                                select (tab1, struct2))
+                        .ToAsync().Match(
+                            r =>
+                            {
+                                foreach (var (code, name) in r)
+                                {
+                                    Console.WriteLine($"{code}\t{name}");
+                                }
+                            },
+                            l => Console.WriteLine($"Error: {l.Message}"));
+                }
+
                 for (var run = 0; run < repeats; run++)
                 {
                     Console.WriteLine($"starting Test Run {run+1} of {repeats}\tTest 01");


### PR DESCRIPTION
This PR adds following extension methods:

- _MapStructure_ on `ITable `to map the rows of _the_ table by a mapper func  
- _MapStructure_ on `IDataContainer` to map the rows of _a_ structure by a mapper func
- _MapTable_ on `IDataContainer` to map the rows of _a_ table by a mapper func
- _MapStructure_ on  `Task<Either<RfcErrorInfo,IFunction>>`to call MapStructure with BindAsync and returns a `EitherAsync`
- _MapTable_ on `Task<Either<RfcErrorInfo,IFunction>>`  to call MapTable with BindAsync and returns a `EitherAsync`
- _CallFunction_ methods to handle `EitherAsync `output without need to call ToEither

closes #15 