### PR TITLE
prefer EitherAsync instead of Task<Either<>>

### DIFF
--- a/src/YaNco.Abstractions/IConnection.cs
+++ b/src/YaNco.Abstractions/IConnection.cs
@@ -6,11 +6,11 @@ namespace Dbosoft.YaNco
 {
     public interface IConnection : IDisposable
     {
-        Task<Either<RfcErrorInfo, Unit>> CommitAndWait();
-        Task<Either<RfcErrorInfo, Unit>> Commit();
-        Task<Either<RfcErrorInfo, Unit>> Rollback();
-        Task<Either<RfcErrorInfo, IFunction>> CreateFunction(string name);
-        Task<Either<RfcErrorInfo, Unit>> InvokeFunction(IFunction function);
-        Task<Either<RfcErrorInfo, Unit>> AllowStartOfPrograms(StartProgramDelegate callback);
+        EitherAsync<RfcErrorInfo, Unit> CommitAndWait();
+        EitherAsync<RfcErrorInfo, Unit> Commit();
+        EitherAsync<RfcErrorInfo, Unit> Rollback();
+        EitherAsync<RfcErrorInfo, IFunction> CreateFunction(string name);
+        EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function);
+        EitherAsync<RfcErrorInfo, Unit> AllowStartOfPrograms(StartProgramDelegate callback);
     }
 }

--- a/src/YaNco.Abstractions/IRfcContext.cs
+++ b/src/YaNco.Abstractions/IRfcContext.cs
@@ -7,11 +7,16 @@ namespace Dbosoft.YaNco
 {
     public interface IRfcContext : IDisposable
     {
-        Task<Either<RfcErrorInfo, IFunction>> CreateFunction(string name);
-        Task<Either<RfcErrorInfo, Unit>> InvokeFunction(IFunction function);
-        Task<Either<RfcErrorInfo, IRfcContext>> Ping();
-        Task<Either<RfcErrorInfo, Unit>> Commit();
-        Task<Either<RfcErrorInfo, Unit>> CommitAndWait();
-        Task<Either<RfcErrorInfo, Unit>> Rollback();
+        EitherAsync<RfcErrorInfo, IFunction> CreateFunction(string name);
+        EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function);
+        EitherAsync<RfcErrorInfo, IRfcContext> Ping();
+        EitherAsync<RfcErrorInfo, Unit> Commit();
+        EitherAsync<RfcErrorInfo, Unit> CommitAndWait();
+        EitherAsync<RfcErrorInfo, Unit> Rollback();
+
+        Task<Either<RfcErrorInfo, IRfcContext>> PingAsync();
+        Task<Either<RfcErrorInfo, Unit>> CommitAsync();
+        Task<Either<RfcErrorInfo, Unit>> CommitAndWaitAsync();
+        Task<Either<RfcErrorInfo, Unit>> RollbackAsync();
     }
 }

--- a/src/YaNco.Abstractions/YaNco.Abstractions.csproj
+++ b/src/YaNco.Abstractions/YaNco.Abstractions.csproj
@@ -20,7 +20,7 @@ This package contains abstraction definitions.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="1.0.0" />
+    <PackageReference Include="Dbosoft.Functional" Version="2.0.0-ci.7" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/YaNco.Abstractions/YaNco.Abstractions.csproj
+++ b/src/YaNco.Abstractions/YaNco.Abstractions.csproj
@@ -20,7 +20,7 @@ This package contains abstraction definitions.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="2.0.0-ci.7" />
+    <PackageReference Include="Dbosoft.Functional" Version="2.0.0-beta.1" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/YaNco.Core/Connection.cs
+++ b/src/YaNco.Core/Connection.cs
@@ -69,47 +69,46 @@ namespace Dbosoft.YaNco
                 });
         }
 
-        public static Task<Either<RfcErrorInfo,IConnection>> Create(IDictionary<string, string> connectionParams, IRfcRuntime runtime)
+        public static EitherAsync<RfcErrorInfo,IConnection> Create(IDictionary<string, string> connectionParams, IRfcRuntime runtime)
         {
-            return runtime.OpenConnection(connectionParams).Map(handle => (IConnection) new Connection(handle, runtime)).AsTask();
+            return runtime.OpenConnection(connectionParams).ToAsync().Map(handle => (IConnection) new Connection(handle, runtime));
         }
 
-
-        public Task<Either<RfcErrorInfo, Unit>> CommitAndWait()
+        public EitherAsync<RfcErrorInfo, Unit> CommitAndWait()
         {
             return CreateFunction("BAPI_TRANSACTION_COMMIT")
                 .SetField("WAIT", "X")
-                .MapAsync(f => f.Apply(InvokeFunction).Map(u => f))
+                .Bind(f => f.Apply(InvokeFunction).Map(u => f))
                 .HandleReturn()
-                .MapAsync(f => Unit.Default);
+                .Map(f => Unit.Default);
 
         }
 
-        public Task<Either<RfcErrorInfo, Unit>> Commit()
+        public EitherAsync<RfcErrorInfo, Unit> Commit()
         {
             return CreateFunction("BAPI_TRANSACTION_COMMIT")
-                .MapAsync(f => f.Apply(InvokeFunction).Map(u=>f))
+                .Bind(f => f.Apply(InvokeFunction).Map(u=>f))
                 .HandleReturn()
-                .MapAsync(f => Unit.Default);
+                .Map(f => Unit.Default);
 
         }
 
-        public Task<Either<RfcErrorInfo, Unit>> Rollback()
+        public EitherAsync<RfcErrorInfo, Unit> Rollback()
         {
             return CreateFunction("BAPI_TRANSACTION_ROLLBACK")
-                .BindAsync(InvokeFunction);
+                .Bind(InvokeFunction);
 
         }
 
 
-        public Task<Either<RfcErrorInfo, IFunction>> CreateFunction(string name) =>
-            _stateAgent.Tell(new CreateFunctionMessage(name)).MapAsync(r => (IFunction) r);
+        public EitherAsync<RfcErrorInfo, IFunction> CreateFunction(string name) =>
+            _stateAgent.Tell(new CreateFunctionMessage(name)).ToAsync().Map(r => (IFunction) r);
 
-        public Task<Either<RfcErrorInfo, Unit>> InvokeFunction(IFunction function) =>
-            _stateAgent.Tell(new InvokeFunctionMessage(function)).MapAsync(r => Unit.Default);
+        public EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function) =>
+            _stateAgent.Tell(new InvokeFunctionMessage(function)).ToAsync().Map(r => Unit.Default);
 
-        public Task<Either<RfcErrorInfo, Unit>> AllowStartOfPrograms(StartProgramDelegate callback) =>
-            _stateAgent.Tell(new AllowStartOfProgramsMessage(callback)).MapAsync(r => Unit.Default);
+        public EitherAsync<RfcErrorInfo, Unit> AllowStartOfPrograms(StartProgramDelegate callback) =>
+            _stateAgent.Tell(new AllowStartOfProgramsMessage(callback)).ToAsync().Map(r => Unit.Default);
 
 
         private class AgentMessage

--- a/src/YaNco.Core/FunctionalDataContainerExtensions.cs
+++ b/src/YaNco.Core/FunctionalDataContainerExtensions.cs
@@ -1,46 +1,39 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using LanguageExt;
 
 namespace Dbosoft.YaNco
 {
     public static class FunctionalDataContainerExtensions
     {
-        public static Either<RfcErrorInfo, TDataContainer> SetField<TDataContainer, T>(this Either<RfcErrorInfo, TDataContainer> self, string name, T value)
+        public static EitherAsync<RfcErrorInfo, TDataContainer> SetField<TDataContainer, T>(this EitherAsync<RfcErrorInfo, TDataContainer> self, string name, T value)
             where TDataContainer : IDataContainer
         {
-            return self.Bind(s => s.SetField(name, value).Map(u=> s));
-        }
-
-        public static Task<Either<RfcErrorInfo, TDataContainer>> SetField<TDataContainer, T>(this Task<Either<RfcErrorInfo, TDataContainer>> self, string name, T value)
-            where TDataContainer : IDataContainer
-        {
-            return self.BindAsync(s => s.SetField(name, value).Map(u => s));
+            return self.Bind(s => s.SetField(name, value).Map(u => s).ToAsync());
         }
 
         
-        public static Task<Either<RfcErrorInfo, TDataContainer>> SetStructure<TDataContainer>(this Task<Either<RfcErrorInfo, TDataContainer>> self, string structureName, Func<Either<RfcErrorInfo, IStructure>, Either<RfcErrorInfo, IStructure>> map)
+        public static EitherAsync<RfcErrorInfo, TDataContainer> SetStructure<TDataContainer>(this EitherAsync<RfcErrorInfo, TDataContainer> self, string structureName, Func<Either<RfcErrorInfo, IStructure>, Either<RfcErrorInfo, IStructure>> map)
             where TDataContainer : IDataContainer
         {
-            return self.BindAsync(dc => dc.GetStructure(structureName).Use(used => used.Apply(map).Map(u => dc)));
+            return self.Bind(dc => dc.GetStructure(structureName).Use(used => used.Apply(map).Map(u => dc)).ToAsync());
         }
 
-        public static Task<Either<RfcErrorInfo, TDataContainer>> SetTable<TDataContainer, TInput>(
-            this Task<Either<RfcErrorInfo, TDataContainer>> self, string tableName,
+        public static EitherAsync<RfcErrorInfo, TDataContainer> SetTable<TDataContainer, TInput>(
+            this EitherAsync<RfcErrorInfo, TDataContainer> self, string tableName,
             IEnumerable<TInput> inputList,
             Func<Either<RfcErrorInfo, IStructure>, TInput, Either<RfcErrorInfo, IStructure>> map)
             where TDataContainer : IDataContainer
             => SetTable(self, tableName, () => inputList, map);
 
-        public static Task<Either<RfcErrorInfo, TDataContainer>> SetTable<TDataContainer, TInput>(this Task<Either<RfcErrorInfo, TDataContainer>> self, string tableName, Func<IEnumerable<TInput>> inputListFunc, Func<Either<RfcErrorInfo, IStructure>, TInput, Either<RfcErrorInfo, IStructure>> map)
+        public static EitherAsync<RfcErrorInfo, TDataContainer> SetTable<TDataContainer, TInput>(this EitherAsync<RfcErrorInfo, TDataContainer> self, string tableName, Func<IEnumerable<TInput>> inputListFunc, Func<Either<RfcErrorInfo, IStructure>, TInput, Either<RfcErrorInfo, IStructure>> map)
             where TDataContainer : IDataContainer
         {
-            return self.BindAsync(dc => dc.GetTable(tableName).Use(used=> used.Map(table => (dc, table, inputListFunc))
+            return self.Bind(dc => dc.GetTable(tableName).Use(used=> used.Map(table => (dc, table, inputListFunc))
 
                     .Bind(t => t.inputListFunc().Map(
                         input => t.table.AppendRow().Apply(row=>map(row,input))
-                    ).Traverse(l => l).Map(_ => dc))));
+                    ).Traverse(l => l).Map(_ => dc))).ToAsync());
 
         }
 

--- a/src/YaNco.Core/RfcContext.cs
+++ b/src/YaNco.Core/RfcContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using LanguageExt;
@@ -8,55 +9,77 @@ namespace Dbosoft.YaNco
 
     public class RfcContext : IRfcContext
     {
-        private readonly Func<Task<Either<RfcErrorInfo, IConnection>>> _connectionBuilder;
+        private readonly Func<EitherAsync<RfcErrorInfo, IConnection>> _connectionBuilder;
         private Option<IConnection> _connection;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
 
-        public RfcContext(Func<Task<Either<RfcErrorInfo, IConnection>>> connectionBuilder)
+        public RfcContext(IDictionary<string, string> connectionParams, ILogger logger = null)
+        {
+            _connectionBuilder = () => Connection.Create(connectionParams, new RfcRuntime(logger));
+        }
+
+        public RfcContext(Func<EitherAsync<RfcErrorInfo, IConnection>> connectionBuilder)
         {
             _connectionBuilder = connectionBuilder;
         }
 
-        private async Task<Either<RfcErrorInfo, IConnection>> GetConnection()
+        private EitherAsync<RfcErrorInfo, IConnection> GetConnection()
         {
-            await _semaphore.WaitAsync().ConfigureAwait(false);
-            try
+
+            async Task<Either<RfcErrorInfo, IConnection>> GetConnectionAsync()
             {
-                return await _connection.MatchAsync(s => Prelude.Right(s),
-                    async () =>
-                    {
-                        var res = await _connectionBuilder();
-                        res.Map(connection => _connection = Prelude.Some(connection));
-                        return res;
-                    }).ConfigureAwait(false);
+                await _semaphore.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    return await _connection.MatchAsync(s => Prelude.Right(s),
+                        async () =>
+                        {
+                            var res = await _connectionBuilder().ToEither();
+                            res.Map(connection => _connection = Prelude.Some(connection));
+                            return res;
+                        }).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _semaphore.Release();
+                }
             }
-            finally
-            {
-                _semaphore.Release();
-            }
+
+            return GetConnectionAsync().ToAsync();
         }
 
 
-        public Task<Either<RfcErrorInfo, Unit>> InvokeFunction(IFunction function)
+        public EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function)
         {
-            return GetConnection().BindAsync(conn => conn.InvokeFunction(function));            
+            return GetConnection()
+                .Bind(conn => conn.InvokeFunction(function));            
         }
 
-        public Task<Either<RfcErrorInfo, IRfcContext>> Ping()
+        public EitherAsync<RfcErrorInfo, IRfcContext> Ping()
         {
             return CreateFunction("RFC_PING")
-                .BindAsync(InvokeFunction)
-                .MapAsync(r => (IRfcContext) this );
+                .Bind(InvokeFunction)
+                .Map(r => (IRfcContext) this );
         }
 
-        public Task<Either<RfcErrorInfo, IFunction>> CreateFunction(string name) => GetConnection().BindAsync(conn => conn.CreateFunction(name));
+        public Task<Either<RfcErrorInfo, IRfcContext>> PingAsync()
+        {
+            return Ping().ToEither();
+        }
 
-        public Task<Either<RfcErrorInfo, Unit>> Commit() => GetConnection().BindAsync(conn => conn.Commit());
 
-        public Task<Either<RfcErrorInfo, Unit>> CommitAndWait() => GetConnection().BindAsync(conn => conn.CommitAndWait());
+        public EitherAsync<RfcErrorInfo, IFunction> CreateFunction(string name) => GetConnection().Bind(conn => conn.CreateFunction(name));
 
-        public Task<Either<RfcErrorInfo, Unit>> Rollback() => GetConnection().BindAsync(conn => conn.Rollback());
+        public EitherAsync<RfcErrorInfo, Unit> Commit() => GetConnection().Bind(conn => conn.Commit());
 
+        public EitherAsync<RfcErrorInfo, Unit> CommitAndWait() => GetConnection().Bind(conn => conn.CommitAndWait());
+
+        public EitherAsync<RfcErrorInfo, Unit> Rollback() => GetConnection().Bind(conn => conn.Rollback());
+
+        public Task<Either<RfcErrorInfo, Unit>> CommitAsync() => Commit().ToEither();
+
+        public Task<Either<RfcErrorInfo, Unit>> CommitAndWaitAsync() => CommitAndWait().ToEither();
+        public Task<Either<RfcErrorInfo, Unit>> RollbackAsync() => Rollback().ToEither();
 
         public void Dispose()
         {

--- a/src/YaNco.Core/YaNco.Core.csproj
+++ b/src/YaNco.Core/YaNco.Core.csproj
@@ -22,7 +22,7 @@ This package contains the core implementation.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="2.0.0-ci.7" />
+    <PackageReference Include="Dbosoft.Functional" Version="2.0.0-beta.1" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/YaNco.Core/YaNco.Core.csproj
+++ b/src/YaNco.Core/YaNco.Core.csproj
@@ -22,7 +22,7 @@ This package contains the core implementation.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="1.0.0" />
+    <PackageReference Include="Dbosoft.Functional" Version="2.0.0-ci.7" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
Refactored message signatures to use EitherAsync instead of Task<Either<>>:

- connection will only use EitherAsync (low level api, only used on method chains)
- RfcContext async methods changed to EitherAsync. Additional overloads added with Async name that can still be used for async/wait
- CallFunctions async methods changed to EitherAsync. Additional overloads added with Async name that can still be used for async/wait
- removed EitherAsync overloads for MapStructure and MapTable as they will be used for Output only. 
- CallFunction Output function changed to directly Map to IFunction (no more need to use func.Map(f=>

