### PR TITLE
removed the simplified RfcContext constructor

### DIFF
--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public class ConnectionBuilder
+    {
+        private readonly IDictionary<string, string> _connectionParam;
+        private StartProgramDelegate _startProgramDelegate;
+        private Action<RfcRuntimeConfigurer> _configureRuntime = (c) => {};
+        private Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo,IConnection>> 
+            _connectionFactory = Connection.Create;
+
+        public ConnectionBuilder(IDictionary<string, string> connectionParam)
+        {
+            _connectionParam = connectionParam;
+        }
+
+        public ConnectionBuilder ConfigureRuntime(Action<RfcRuntimeConfigurer> configure)
+        {
+            _configureRuntime = configure;
+            return this;
+        }
+
+        public ConnectionBuilder WithStartProgramCallback(StartProgramDelegate startProgramDelegate)
+        {
+            _startProgramDelegate = startProgramDelegate;
+            return this;
+        }
+
+        public ConnectionBuilder UseFactory(
+            Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo, IConnection>> factory)
+        {
+            _connectionFactory = factory;
+            return this;
+        }
+
+        public Func<EitherAsync<RfcErrorInfo, IConnection>> Build()
+        {
+            var runtimeConfigurer = new RfcRuntimeConfigurer();
+            _configureRuntime(runtimeConfigurer);
+            var runtime = runtimeConfigurer.Create();
+            
+            if(_startProgramDelegate == null)
+                return () => Connection.Create(_connectionParam, runtime);
+
+
+            return () => (from c in Connection.Create(_connectionParam, runtime)
+                from _ in c.AllowStartOfPrograms(_startProgramDelegate)
+                select c);
+        }
+    }
+}

--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -43,10 +43,10 @@ namespace Dbosoft.YaNco
             var runtime = runtimeConfigurer.Create();
             
             if(_startProgramDelegate == null)
-                return () => Connection.Create(_connectionParam, runtime);
+                return () => _connectionFactory(_connectionParam, runtime);
 
 
-            return () => (from c in Connection.Create(_connectionParam, runtime)
+            return () => (from c in _connectionFactory(_connectionParam, runtime)
                 from _ in c.AllowStartOfPrograms(_startProgramDelegate)
                 select c);
         }

--- a/src/YaNco.Core/RfcContext.cs
+++ b/src/YaNco.Core/RfcContext.cs
@@ -13,11 +13,6 @@ namespace Dbosoft.YaNco
         private Option<IConnection> _connection;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
 
-        public RfcContext(IDictionary<string, string> connectionParams, ILogger logger = null)
-        {
-            _connectionBuilder = () => Connection.Create(connectionParams, new RfcRuntime(logger));
-        }
-
         public RfcContext(Func<EitherAsync<RfcErrorInfo, IConnection>> connectionBuilder)
         {
             _connectionBuilder = connectionBuilder;

--- a/src/YaNco.Core/RfcMappingConfigurer.cs
+++ b/src/YaNco.Core/RfcMappingConfigurer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Dbosoft.YaNco;
+using Dbosoft.YaNco.TypeMapping;
+
+public class RfcMappingConfigurer
+{
+    private Func<IEnumerable<Type>, IEnumerable<Type>,IFieldMapper>
+        _mappingFactory = RfcRuntime.CreateDefaultFieldMapper;
+
+    private readonly List<Type> _fromRfcMappingTypes = new List<Type>();
+    private readonly List<Type> _toRfcMappingTypes = new List<Type>();
+
+    public RfcMappingConfigurer UseFactory(Func<IEnumerable<Type>, IEnumerable<Type>, IFieldMapper> factory)
+    {
+        _mappingFactory = factory;
+        return this;
+    }
+
+    public RfcMappingConfigurer AddToRfcMapper(Type mapper)
+    {
+        _toRfcMappingTypes.Add(mapper);
+        return this;
+    }
+
+    public RfcMappingConfigurer AddFromRfcMapper(Type mapper)
+    {
+        _fromRfcMappingTypes.Add(mapper);
+        return this;
+    }
+
+    internal IFieldMapper Create()
+    {
+        return _mappingFactory(_fromRfcMappingTypes, _toRfcMappingTypes);
+    }
+}

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -16,12 +16,16 @@ namespace Dbosoft.YaNco
         public RfcRuntime(ILogger logger = null, IFieldMapper fieldMapper = null, RfcRuntimeOptions options = null)
         {
             Logger = logger == null ? Option<ILogger>.None : Option<ILogger>.Some(logger);
-            _fieldMapper = fieldMapper ?? 
-                           new DefaultFieldMapper(
-                                new CachingConverterResolver(
-                                    DefaultConverterResolver.CreateWithBuildInConverters()));
-
+            _fieldMapper = fieldMapper ?? CreateDefaultFieldMapper();
             Options = options ?? new RfcRuntimeOptions();
+        }
+
+        public static IFieldMapper CreateDefaultFieldMapper(IEnumerable<Type> fromRfcConverters = null,
+            IEnumerable<Type> toRfcConverters = null)
+        {
+            return new DefaultFieldMapper(
+                new CachingConverterResolver(
+                    DefaultConverterResolver.CreateWithBuildInConverters(fromRfcConverters, toRfcConverters)));
         }
 
         public RfcRuntimeOptions Options { get; }

--- a/src/YaNco.Core/RfcRuntimeConfigurer.cs
+++ b/src/YaNco.Core/RfcRuntimeConfigurer.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Dbosoft.YaNco;
+using Dbosoft.YaNco.TypeMapping;
+
+namespace Dbosoft.YaNco
+{
+    public class RfcRuntimeConfigurer
+    {
+        private Func<ILogger, IFieldMapper, RfcRuntimeOptions, IRfcRuntime>
+            _runtimeFactory = (logger, mapper, options) => new RfcRuntime(logger, mapper, options);
+
+        private ILogger _logger;
+        private RfcRuntimeOptions _options = new RfcRuntimeOptions();
+        private Action<RfcMappingConfigurer> _configureMapping = (m) => { };
+
+        public RfcRuntimeConfigurer WithLogger(ILogger logger)
+        {
+            _logger = logger;
+            return this;
+        }
+
+        public RfcRuntimeConfigurer ConfigureOptions(Action<RfcRuntimeOptions> configure)
+        {
+            configure(_options);
+            return this;
+        }
+
+        public RfcRuntimeConfigurer ConfigureMapping(Action<RfcMappingConfigurer> configure)
+        {
+            _configureMapping = configure;
+            return this;
+        }
+
+        public RfcRuntimeConfigurer UseFactory(Func<ILogger, IFieldMapper, RfcRuntimeOptions, IRfcRuntime> factory)
+        {
+            _runtimeFactory = factory;
+            return this;
+        }
+
+        internal IRfcRuntime Create()
+        {
+            var mappingConfigurer = new RfcMappingConfigurer();
+            _configureMapping(mappingConfigurer);
+            var mapping = mappingConfigurer.Create();
+            
+            return _runtimeFactory(_logger, mapping,_options);
+        }
+    }
+    
+}

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -57,7 +57,12 @@ namespace SAPSystemTests
                 return RfcErrorInfo.Ok();
             };
 
-            using (var context = new RfcContext(settings, new SimpleConsoleLogger()))
+            var connectionBuilder = new ConnectionBuilder(settings)
+                .WithStartProgramCallback(callback)
+                .ConfigureRuntime(c => 
+                    c.WithLogger(new SimpleConsoleLogger()));
+
+            using (var context = new RfcContext(connectionBuilder.Build()))
             {
                 await context.PingAsync();
 


### PR DESCRIPTION
bad design decision - keep it straight is it was in past and use one constructor
instead added a ConnectionBuilder to fluent build options for connection and runtime.