### PR TITLE
removed the simplified RfcContext constructor (4.x)

### DIFF
--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public class ConnectionBuilder
+    {
+        private readonly IDictionary<string, string> _connectionParam;
+        private StartProgramDelegate _startProgramDelegate;
+        private Action<RfcRuntimeConfigurer> _configureRuntime = (c) => {};
+        private Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo,IConnection>> 
+            _connectionFactory = Connection.Create;
+
+        public ConnectionBuilder(IDictionary<string, string> connectionParam)
+        {
+            _connectionParam = connectionParam;
+        }
+
+        public ConnectionBuilder ConfigureRuntime(Action<RfcRuntimeConfigurer> configure)
+        {
+            _configureRuntime = configure;
+            return this;
+        }
+
+        public ConnectionBuilder WithStartProgramCallback(StartProgramDelegate startProgramDelegate)
+        {
+            _startProgramDelegate = startProgramDelegate;
+            return this;
+        }
+
+        public ConnectionBuilder UseFactory(
+            Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo, IConnection>> factory)
+        {
+            _connectionFactory = factory;
+            return this;
+        }
+
+        public Func<EitherAsync<RfcErrorInfo, IConnection>> Build()
+        {
+            var runtimeConfigurer = new RfcRuntimeConfigurer();
+            _configureRuntime(runtimeConfigurer);
+            var runtime = runtimeConfigurer.Create();
+            
+            if(_startProgramDelegate == null)
+                return () => Connection.Create(_connectionParam, runtime);
+
+
+            return () => (from c in Connection.Create(_connectionParam, runtime)
+                from _ in c.AllowStartOfPrograms(_startProgramDelegate)
+                select c);
+        }
+    }
+}

--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -43,10 +43,10 @@ namespace Dbosoft.YaNco
             var runtime = runtimeConfigurer.Create();
             
             if(_startProgramDelegate == null)
-                return () => Connection.Create(_connectionParam, runtime);
+                return () => _connectionFactory(_connectionParam, runtime);
 
 
-            return () => (from c in Connection.Create(_connectionParam, runtime)
+            return () => (from c in _connectionFactory(_connectionParam, runtime)
                 from _ in c.AllowStartOfPrograms(_startProgramDelegate)
                 select c);
         }

--- a/src/YaNco.Core/RfcContext.cs
+++ b/src/YaNco.Core/RfcContext.cs
@@ -13,10 +13,6 @@ namespace Dbosoft.YaNco
         private Option<IConnection> _connection;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1);
 
-        public RfcContext(IDictionary<string, string> connectionParams, ILogger logger = null)
-        {
-            _connectionBuilder = () => Connection.Create(connectionParams, new RfcRuntime(logger));
-        }
 
         public RfcContext(Func<EitherAsync<RfcErrorInfo, IConnection>> connectionBuilder)
         {

--- a/src/YaNco.Core/RfcMappingConfigurer.cs
+++ b/src/YaNco.Core/RfcMappingConfigurer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Dbosoft.YaNco;
+using Dbosoft.YaNco.TypeMapping;
+
+public class RfcMappingConfigurer
+{
+    private Func<IEnumerable<Type>, IEnumerable<Type>,IFieldMapper>
+        _mappingFactory = RfcRuntime.CreateDefaultFieldMapper;
+
+    private readonly List<Type> _fromRfcMappingTypes = new List<Type>();
+    private readonly List<Type> _toRfcMappingTypes = new List<Type>();
+
+    public RfcMappingConfigurer UseFactory(Func<IEnumerable<Type>, IEnumerable<Type>, IFieldMapper> factory)
+    {
+        _mappingFactory = factory;
+        return this;
+    }
+
+    public RfcMappingConfigurer AddToRfcMapper(Type mapper)
+    {
+        _toRfcMappingTypes.Add(mapper);
+        return this;
+    }
+
+    public RfcMappingConfigurer AddFromRfcMapper(Type mapper)
+    {
+        _fromRfcMappingTypes.Add(mapper);
+        return this;
+    }
+
+    internal IFieldMapper Create()
+    {
+        return _mappingFactory(_fromRfcMappingTypes, _toRfcMappingTypes);
+    }
+}

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -16,11 +16,15 @@ namespace Dbosoft.YaNco
         public RfcRuntime(ILogger logger = null, IFieldMapper fieldMapper = null)
         {
             Logger = logger == null ? Option<ILogger>.None : Option<ILogger>.Some(logger);
-            _fieldMapper = fieldMapper ?? 
-                           new DefaultFieldMapper(
-                                new CachingConverterResolver(
-                                    DefaultConverterResolver.CreateWithBuildInConverters()));
+            _fieldMapper = fieldMapper ?? CreateDefaultFieldMapper();
+        }
 
+        public static IFieldMapper CreateDefaultFieldMapper(IEnumerable<Type> fromRfcConverters = null,
+            IEnumerable<Type> toRfcConverters = null)
+        {
+            return new DefaultFieldMapper(
+                new CachingConverterResolver(
+                    DefaultConverterResolver.CreateWithBuildInConverters(fromRfcConverters, toRfcConverters)));
         }
 
         private Either<RfcErrorInfo, TResult> ResultOrError<TResult>(TResult result, RfcErrorInfo errorInfo, bool logAsError = false)

--- a/src/YaNco.Core/RfcRuntimeConfigurer.cs
+++ b/src/YaNco.Core/RfcRuntimeConfigurer.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Dbosoft.YaNco;
+using Dbosoft.YaNco.TypeMapping;
+
+namespace Dbosoft.YaNco
+{
+    public class RfcRuntimeConfigurer
+    {
+        private Func<ILogger, IFieldMapper, IRfcRuntime>
+            _runtimeFactory = (logger, mapper) => new RfcRuntime(logger, mapper);
+
+        private ILogger _logger;
+        private Action<RfcMappingConfigurer> _configureMapping = (m) => { };
+
+        public RfcRuntimeConfigurer WithLogger(ILogger logger)
+        {
+            _logger = logger;
+            return this;
+        }
+
+
+        public RfcRuntimeConfigurer ConfigureMapping(Action<RfcMappingConfigurer> configure)
+        {
+            _configureMapping = configure;
+            return this;
+        }
+
+        public RfcRuntimeConfigurer UseFactory(Func<ILogger, IFieldMapper, IRfcRuntime> factory)
+        {
+            _runtimeFactory = factory;
+            return this;
+        }
+
+        internal IRfcRuntime Create()
+        {
+            var mappingConfigurer = new RfcMappingConfigurer();
+            _configureMapping(mappingConfigurer);
+            var mapping = mappingConfigurer.Create();
+            
+            return _runtimeFactory(_logger, mapping);
+        }
+    }
+    
+}

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -56,7 +56,11 @@ namespace SAPSystemTests
                 return RfcErrorInfo.Ok();
             };
 
-            using (var context = new RfcContext(settings, new SimpleConsoleLogger()))
+            
+            using (var context = new RfcContext(
+                new ConnectionBuilder(settings)
+                    .ConfigureRuntime(rc=> rc.WithLogger(new SimpleConsoleLogger()))
+                    .Build()))
             {
                 await context.PingAsync();
 


### PR DESCRIPTION
same as #44 but for 4.x branch

bad design decision - keep it straight is it was in past and use one constructor
instead added a ConnectionBuilder to fluent build options for connection and runtime.