### PR TITLE
get and set entire structure from a dictionary

### DIFF
--- a/src/YaNco.Abstractions/IRfcRuntime.cs
+++ b/src/YaNco.Abstractions/IRfcRuntime.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Dbosoft.YaNco;
+using Dbosoft.YaNco.TypeMapping;
 using LanguageExt;
 
 namespace Dbosoft.YaNco
@@ -50,6 +51,7 @@ namespace Dbosoft.YaNco
         Either<RfcErrorInfo, string> GetTimeString(IDataContainerHandle containerHandle, string name);
 
         Option<ILogger> Logger { get; }
+        IFieldMapper FieldMapper { get; }
 
         Either<RfcErrorInfo, Unit> SetFieldValue<T>(IDataContainerHandle handle, T value, Func<Either<RfcErrorInfo, RfcFieldInfo>> func);
         Either<RfcErrorInfo, T> GetFieldValue<T>(IDataContainerHandle handle, Func<Either<RfcErrorInfo, RfcFieldInfo>> func);

--- a/src/YaNco.Abstractions/IStructure.cs
+++ b/src/YaNco.Abstractions/IStructure.cs
@@ -1,6 +1,32 @@
-﻿namespace Dbosoft.YaNco
+﻿using System.Collections.Generic;
+using Dbosoft.YaNco.TypeMapping;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
 {
     public interface IStructure : IDataContainer
     {
+        /// <summary>
+        /// Get RfcFieldInfo for all fields in structure
+        /// </summary>
+        /// <returns></returns>
+        Either<RfcErrorInfo, RfcFieldInfo[]> GetFieldInfos();
+
+        /// <summary>
+        /// Convert all fields in structure to a dictionary. FieldName will be key in dictionary. Each field value will be
+        /// a unconverted AbapValue. Only flat structures are supported.
+        /// </summary>
+        /// <returns></returns>
+        Either<RfcErrorInfo, IDictionary<string,AbapValue>> ToDictionary();
+
+        /// <summary>
+        /// Sets the structure fields from a dictionary. The key of the dictionary has to be the field name.
+        /// The field will not be filled if the key not exists in dictionary.
+        /// Only flat structures are supported.
+        /// </summary>
+        /// <typeparam name="T">Dictionary value type.</typeparam>
+        /// <param name="dictionary"></param>
+        /// <returns></returns>
+        Either<RfcErrorInfo, Unit> SetFromDictionary<T>(IDictionary<string, T> dictionary);
     }
 }

--- a/src/YaNco.Abstractions/TypeMapping/IFieldMapper.cs
+++ b/src/YaNco.Abstractions/TypeMapping/IFieldMapper.cs
@@ -1,4 +1,5 @@
-﻿using LanguageExt;
+﻿using System;
+using LanguageExt;
 
 namespace Dbosoft.YaNco.TypeMapping
 {
@@ -6,6 +7,9 @@ namespace Dbosoft.YaNco.TypeMapping
     {
         Either<RfcErrorInfo, Unit> SetField<T>(T value, FieldMappingContext context);
         Either<RfcErrorInfo, T> GetField<T>(FieldMappingContext context);
-        
+
+        Either<RfcErrorInfo, T> FromAbapValue<T>(AbapValue abapValue);
+        Either<RfcErrorInfo, AbapValue> ToAbapValue<T>(T value, RfcFieldInfo fieldInfo);
+
     }
 }

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -11,12 +11,12 @@ namespace Dbosoft.YaNco
 {
     public class RfcRuntime : IRfcRuntime
     {
-        private readonly IFieldMapper _fieldMapper;
+        public IFieldMapper FieldMapper { get; }
 
         public RfcRuntime(ILogger logger = null, IFieldMapper fieldMapper = null, RfcRuntimeOptions options = null)
         {
             Logger = logger == null ? Option<ILogger>.None : Option<ILogger>.Some(logger);
-            _fieldMapper = fieldMapper ?? CreateDefaultFieldMapper();
+            FieldMapper = fieldMapper ?? CreateDefaultFieldMapper();
             Options = options ?? new RfcRuntimeOptions();
         }
 
@@ -330,7 +330,7 @@ namespace Dbosoft.YaNco
             return func().Bind(fieldInfo =>
             {
                 Logger.IfSome(l => l.LogTrace("setting field value", new { handle, fieldInfo, SourceType= typeof(T) }));
-                return _fieldMapper.SetField(value, new FieldMappingContext(this, handle, fieldInfo));
+                return FieldMapper.SetField(value, new FieldMappingContext(this, handle, fieldInfo));
             });
             
         }
@@ -340,7 +340,7 @@ namespace Dbosoft.YaNco
             return func().Bind(fieldInfo =>
             {
                 Logger.IfSome(l => l.LogTrace("reading field value", new { handle, fieldInfo, TargetType = typeof(T) }));
-                return _fieldMapper.GetField<T>(new FieldMappingContext(this, handle, fieldInfo));
+                return FieldMapper.GetField<T>(new FieldMappingContext(this, handle, fieldInfo));
             });
 
 

--- a/src/YaNco.Core/Structure.cs
+++ b/src/YaNco.Core/Structure.cs
@@ -1,9 +1,58 @@
-﻿namespace Dbosoft.YaNco
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dbosoft.YaNco.TypeMapping;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
 {
     internal class Structure : TypeDescriptionDataContainer, IStructure
     {
         public Structure(IDataContainerHandle handle, IRfcRuntime rfcRuntime) : base(handle, rfcRuntime)
         {
+        }
+
+        public Either<RfcErrorInfo, RfcFieldInfo[]> GetFieldInfos()
+        {
+            return RfcRuntime.GetTypeDescription(Handle).Use(used => used
+                .Bind( handle =>
+                {
+                    return RfcRuntime.GetTypeFieldCount(handle).Bind(fieldCount =>
+                    {
+                        return Enumerable.Range(0, fieldCount).Map(i => 
+                            RfcRuntime.GetTypeFieldDescription(handle, i)).Traverse(l=>l);
+                    });
+
+                })).Map(r => r.ToArray());
+        }
+
+        public Either<RfcErrorInfo, IDictionary<string, AbapValue>> ToDictionary()
+        {
+            return GetFieldInfos()
+                .Bind(fields =>
+                    fields.Map(fieldInfo =>
+                        from fieldValue in RfcRuntime.GetFieldValue<AbapValue>(Handle, () => fieldInfo)
+                        from fieldName in Prelude.Right(fieldInfo.Name).Bind<RfcErrorInfo>()
+                        select (fieldName, fieldValue)
+                    ).Traverse(l => l))
+                .Map(l => l.ToDictionary(
+                    v => v.fieldName,
+                    v => v.fieldValue))
+                .Map(d => (IDictionary<string,AbapValue>) d);
+
+        }
+
+        public Either<RfcErrorInfo, Unit> SetFromDictionary<T>(IDictionary<string, T> dictionary)
+        {
+            return GetFieldInfos()
+                .Bind(fields =>
+                    fields.Map(fieldInfo => 
+                        !dictionary.ContainsKey(fieldInfo.Name) 
+                            ? Unit.Default
+                            : RfcRuntime.SetFieldValue(Handle, dictionary[fieldInfo.Name], () => fieldInfo)
+                            )
+                        .Traverse(l => l))
+                .Map(_ => Unit.Default);
         }
     }
 }

--- a/src/YaNco.Core/TypeDescriptionDataContainer.cs
+++ b/src/YaNco.Core/TypeDescriptionDataContainer.cs
@@ -4,19 +4,19 @@ namespace Dbosoft.YaNco
 {
     internal abstract class TypeDescriptionDataContainer : DataContainer
     {
-        private readonly IDataContainerHandle _handle;
-        private readonly IRfcRuntime _rfcRuntime;
+        protected readonly IDataContainerHandle Handle;
+        protected readonly IRfcRuntime RfcRuntime;
 
         protected TypeDescriptionDataContainer(IDataContainerHandle handle, IRfcRuntime rfcRuntime) : base(handle, rfcRuntime)
         {
-            _handle = handle;
-            _rfcRuntime = rfcRuntime;
+            Handle = handle;
+            RfcRuntime = rfcRuntime;
         }
 
         protected override Either<RfcErrorInfo, RfcFieldInfo> GetFieldInfo(string name)
         {
-            return _rfcRuntime.GetTypeDescription(_handle).Use(used => used
-                .Bind(handle => _rfcRuntime.GetTypeFieldDescription(handle, name)));
+            return RfcRuntime.GetTypeDescription(Handle).Use(used => used
+                .Bind(handle => RfcRuntime.GetTypeFieldDescription(handle, name)));
 
         }
     }


### PR DESCRIPTION
This PR adds the feature to get all fields of a structure in a IDictionary<string,AbapValue> from method GetDictionary.
You can also set now all structure fields from a dictionary with method SetDictionary.

This PR also adds direct access to FieldMapper to IRfcRuntime and methods to FieldMapper to convert from and to AbapValue.