### PR TITLE
allow access to IConnection and IRuntime

### DIFF
--- a/src/YaNco.Abstractions/IConnection.cs
+++ b/src/YaNco.Abstractions/IConnection.cs
@@ -20,6 +20,7 @@ namespace Dbosoft.YaNco
         EitherAsync<RfcErrorInfo, Unit> Cancel();
 
         bool Disposed { get; }
+        IRfcRuntime RfcRuntime { get;  }
 
     }
 }

--- a/src/YaNco.Abstractions/IRfcContext.cs
+++ b/src/YaNco.Abstractions/IRfcContext.cs
@@ -29,5 +29,8 @@ namespace Dbosoft.YaNco
         Task<Either<RfcErrorInfo, Unit>> CommitAndWaitAsync(CancellationToken cancellationToken);
         Task<Either<RfcErrorInfo, Unit>> RollbackAsync();
         Task<Either<RfcErrorInfo, Unit>> RollbackAsync(CancellationToken cancellationToken);
+
+        EitherAsync<RfcErrorInfo, IConnection> GetConnection();
+
     }
 }

--- a/src/YaNco.Core/Connection.cs
+++ b/src/YaNco.Core/Connection.cs
@@ -10,7 +10,7 @@ namespace Dbosoft.YaNco
     public class Connection : IConnection
     {
         private readonly IConnectionHandle _connectionHandle;
-        private readonly IRfcRuntime _rfcRuntime;
+        public IRfcRuntime RfcRuntime { get; }
         private readonly IAgent<AgentMessage, Either<RfcErrorInfo, object>> _stateAgent;
         public bool Disposed { get; private set; }
         private bool _functionCalled;
@@ -20,7 +20,7 @@ namespace Dbosoft.YaNco
             IRfcRuntime rfcRuntime)
         {
             _connectionHandle = connectionHandle;
-            _rfcRuntime = rfcRuntime;
+            RfcRuntime = rfcRuntime;
 
             _stateAgent = Agent.Start<IConnectionHandle, AgentMessage, Either<RfcErrorInfo, object>>(
                 connectionHandle, (handle, msg) =>
@@ -136,7 +136,7 @@ namespace Dbosoft.YaNco
 
         public EitherAsync<RfcErrorInfo, Unit> Cancel()
         {
-            var res = _rfcRuntime.CancelConnection(_connectionHandle).ToAsync();
+            var res = RfcRuntime.CancelConnection(_connectionHandle).ToAsync();
             Dispose();
             return res;
         }

--- a/src/YaNco.Core/RfcContext.cs
+++ b/src/YaNco.Core/RfcContext.cs
@@ -16,8 +16,8 @@ namespace Dbosoft.YaNco
         {
             _connectionBuilder = connectionBuilder;
         }
-
-        private EitherAsync<RfcErrorInfo, IConnection> GetConnection()
+        
+        public EitherAsync<RfcErrorInfo, IConnection> GetConnection()
         {
 
             async Task<Either<RfcErrorInfo, IConnection>> GetConnectionAsync()


### PR DESCRIPTION
It is currently not possible to directly access the connection of a IRfcContext. Also it is not possible to access the RfcRuntime of the connection. 
Added a property for RfcRuntime on IConnection and made GetConnection() method public.