### PR TITLE
bind callback to connection (4.0)

### DIFF
--- a/src/YaNco.Core/Internal/ConnectionHandle.cs
+++ b/src/YaNco.Core/Internal/ConnectionHandle.cs
@@ -15,7 +15,9 @@ namespace Dbosoft.YaNco.Internal
         {
             if (Ptr == IntPtr.Zero) return;
 
+            Api.RemoveCallbackHandler(Ptr);
             Interopt.RfcCloseConnection(Ptr, out _);
+            
             Ptr = IntPtr.Zero;
         }
     }


### PR DESCRIPTION
same as #48 for 4.0 branch

If multiple connections are opened with callbacks, the callbacks are only processed by one of them.
With this PR the callback will be correctly bound to the connection.