### PR TITLE
pin Dbosoft.Functional version (3.x)

### DIFF
--- a/src/YaNco.Abstractions/YaNco.Abstractions.csproj
+++ b/src/YaNco.Abstractions/YaNco.Abstractions.csproj
@@ -20,7 +20,7 @@ This package contains abstraction definitions.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="(1.0,2.0)" />
+    <PackageReference Include="Dbosoft.Functional" Version="[1.0,2.0)" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/YaNco.Abstractions/YaNco.Abstractions.csproj
+++ b/src/YaNco.Abstractions/YaNco.Abstractions.csproj
@@ -20,7 +20,7 @@ This package contains abstraction definitions.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="1.0.0" />
+    <PackageReference Include="Dbosoft.Functional" Version="(1.0,2.0)" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/YaNco.Core/YaNco.Core.csproj
+++ b/src/YaNco.Core/YaNco.Core.csproj
@@ -22,7 +22,7 @@ This package contains the core implementation.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="1.0.0" />
+    <PackageReference Include="Dbosoft.Functional" Version="(1.0,2.0)" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/YaNco.Core/YaNco.Core.csproj
+++ b/src/YaNco.Core/YaNco.Core.csproj
@@ -22,7 +22,7 @@ This package contains the core implementation.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Functional" Version="(1.0,2.0)" />
+    <PackageReference Include="Dbosoft.Functional" Version="[1.0,2.0)" />
     <PackageReference Include="GitVersionTask" Version="5.3.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
closes #51 

added constraint to Dbosoft.Functional reference as only versions >= 1.0 and < 2.0 are supported.