### PR TITLE
Generic client callback registration

### DIFF
--- a/YaNco.sln.DotSettings
+++ b/YaNco.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Abap/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dbosoft/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dbosoft/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=sysid/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/YaNco.Abstractions/IConnection.cs
+++ b/src/YaNco.Abstractions/IConnection.cs
@@ -16,6 +16,8 @@ namespace Dbosoft.YaNco
         EitherAsync<RfcErrorInfo, IFunction> CreateFunction(string name);
         EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function);
         EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function, CancellationToken cancellationToken);
+
+        [Obsolete("Use method WithStartProgramCallback of ConnectionBuilder instead. This method will be removed in next major release.")]
         EitherAsync<RfcErrorInfo, Unit> AllowStartOfPrograms(StartProgramDelegate callback);
         EitherAsync<RfcErrorInfo, Unit> Cancel();
 

--- a/src/YaNco.Abstractions/IDataContainer.cs
+++ b/src/YaNco.Abstractions/IDataContainer.cs
@@ -12,5 +12,6 @@ namespace Dbosoft.YaNco
         Either<RfcErrorInfo, byte[]> GetFieldBytes(string name);
         Either<RfcErrorInfo, IStructure> GetStructure(string name);
         Either<RfcErrorInfo, ITable> GetTable(string name);
+        Either<RfcErrorInfo, ITypeDescriptionHandle> GetTypeDescription();
     }
 }

--- a/src/YaNco.Abstractions/IFunctionBuilder.cs
+++ b/src/YaNco.Abstractions/IFunctionBuilder.cs
@@ -1,0 +1,18 @@
+﻿using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public interface IFunctionBuilder
+    {
+        IFunctionBuilder AddParameter(RfcParameterDescription parameter);
+        IFunctionBuilder AddChar(string name, RfcDirection direction, uint length, bool optional = true, string defaultValue = null);
+        IFunctionBuilder AddInt(string name, RfcDirection direction, bool optional = true, int defaultValue = 0);
+        IFunctionBuilder AddLong(string name, RfcDirection direction, bool optional = true, long defaultValue = 0);
+        IFunctionBuilder AddString(string name, RfcDirection direction, bool optional = true, uint length = 0, string defaultValue = null);
+        IFunctionBuilder AddStructure(string name, RfcDirection direction, ITypeDescriptionHandle typeHandle, bool optional = true);
+        IFunctionBuilder AddStructure(string name, RfcDirection direction, IStructure structure, bool optional = true);
+        IFunctionBuilder AddTable(string name, RfcDirection direction, ITable table, bool optional = true);
+        IFunctionBuilder AddTable(string name, RfcDirection direction, ITypeDescriptionHandle typeHandle, bool optional = true);
+        Either<RfcErrorInfo, IFunctionDescriptionHandle> Build();
+    }
+}

--- a/src/YaNco.Abstractions/IRfcHandle.cs
+++ b/src/YaNco.Abstractions/IRfcHandle.cs
@@ -1,0 +1,6 @@
+﻿namespace Dbosoft.YaNco
+{
+    public interface IRfcHandle
+    {
+    }
+}

--- a/src/YaNco.Abstractions/IRfcRuntime.cs
+++ b/src/YaNco.Abstractions/IRfcRuntime.cs
@@ -8,6 +8,7 @@ namespace Dbosoft.YaNco
 {
     public interface IRfcRuntime
     {
+        [Obsolete("Use method AllowStartOfPrograms of ConnectionBuilder. This method will be removed in next major release.")]
         Either<RfcErrorInfo, Unit> AllowStartOfPrograms(IConnectionHandle connectionHandle, StartProgramDelegate callback);
         Either<RfcErrorInfo, IStructureHandle> AppendTableRow(ITableHandle tableHandle);
         Either<RfcErrorInfo, IFunctionHandle> CreateFunction(IFunctionDescriptionHandle descriptionHandle);
@@ -16,8 +17,13 @@ namespace Dbosoft.YaNco
         Either<RfcErrorInfo, IFunctionDescriptionHandle> GetFunctionDescription(IFunctionHandle functionHandle);
         Either<RfcErrorInfo, string> GetFunctionName(IFunctionDescriptionHandle descriptionHandle);
         Either<RfcErrorInfo, int> GetFunctionParameterCount(IFunctionDescriptionHandle descriptionHandle);
+        Either<RfcErrorInfo, IFunctionDescriptionHandle> CreateFunctionDescription(string functionName);
+        Either<RfcErrorInfo, IFunctionDescriptionHandle> AddFunctionParameter(IFunctionDescriptionHandle descriptionHandle, RfcParameterDescription parameterDescription);
         Either<RfcErrorInfo, RfcParameterInfo> GetFunctionParameterDescription(IFunctionDescriptionHandle descriptionHandle, int index);
         Either<RfcErrorInfo, RfcParameterInfo> GetFunctionParameterDescription(IFunctionDescriptionHandle descriptionHandle, string name);
+        Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, IFunction function, Func<IFunction, Either<RfcErrorInfo, Unit>> handler);
+        Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, IFunctionDescriptionHandle descriptionHandle,
+            Func<IFunction, Either<RfcErrorInfo, Unit>> handler);
         Either<RfcErrorInfo, IStructureHandle> GetStructure(IDataContainerHandle dataContainer, string name);
         Either<RfcErrorInfo, ITableHandle> GetTable(IDataContainerHandle dataContainer, string name);
         Either<RfcErrorInfo, ITableHandle> CloneTable(ITableHandle tableHandle);

--- a/src/YaNco.Abstractions/IRfcRuntime.cs
+++ b/src/YaNco.Abstractions/IRfcRuntime.cs
@@ -21,8 +21,10 @@ namespace Dbosoft.YaNco
         Either<RfcErrorInfo, IFunctionDescriptionHandle> AddFunctionParameter(IFunctionDescriptionHandle descriptionHandle, RfcParameterDescription parameterDescription);
         Either<RfcErrorInfo, RfcParameterInfo> GetFunctionParameterDescription(IFunctionDescriptionHandle descriptionHandle, int index);
         Either<RfcErrorInfo, RfcParameterInfo> GetFunctionParameterDescription(IFunctionDescriptionHandle descriptionHandle, string name);
-        Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, IFunction function, Func<IFunction, Either<RfcErrorInfo, Unit>> handler);
-        Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, IFunctionDescriptionHandle descriptionHandle,
+        Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, 
+            string functionName, IFunction function, Func<IFunction, Either<RfcErrorInfo, Unit>> handler);
+        Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, string functionName, 
+            IFunctionDescriptionHandle descriptionHandle,
             Func<IFunction, Either<RfcErrorInfo, Unit>> handler);
         Either<RfcErrorInfo, IStructureHandle> GetStructure(IDataContainerHandle dataContainer, string name);
         Either<RfcErrorInfo, ITableHandle> GetTable(IDataContainerHandle dataContainer, string name);
@@ -64,6 +66,7 @@ namespace Dbosoft.YaNco
         Either<RfcErrorInfo, T> GetFieldValue<T>(IDataContainerHandle handle, Func<Either<RfcErrorInfo, RfcFieldInfo>> func);
 
         RfcRuntimeOptions Options { get; }
+        bool IsFunctionHandlerRegistered(string sysId, string functionName);
     }
 
 

--- a/src/YaNco.Core/CalledFunction.cs
+++ b/src/YaNco.Core/CalledFunction.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public readonly struct CalledFunction
+    {
+        public readonly IFunction Function;
+
+        internal CalledFunction(IFunction function)
+        {
+            Function = function;
+        }
+
+        public Either<RfcErrorInfo, FunctionInput<TInput>> Input<TInput>(Func<Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, TInput>> inputFunc)
+        {
+            var function = Function;
+            return inputFunc(Prelude.Right(function)).Map(input => new FunctionInput<TInput>(input, function));
+        }
+
+
+    }
+
+    public readonly struct FunctionInput<TInput>
+    {
+        public readonly TInput Input;
+        public readonly IFunction Function;
+
+        internal FunctionInput(TInput input, IFunction function)
+        {
+            Input = input;
+            Function = function;
+        }
+
+        public FunctionProcessed<TOutput> Process<TOutput>(Func<TInput, TOutput> processFunc)
+        {
+            return new FunctionProcessed<TOutput>(processFunc(Input), Function);
+        }
+
+        public void Deconstruct(out IFunction function, out TInput input)
+        {
+            function = Function;
+            input = Input;
+        }
+    }
+
+    public readonly struct FunctionProcessed<TOutput>
+    {
+        private readonly TOutput _output;
+        private readonly IFunction _function;
+
+        internal FunctionProcessed(TOutput output, IFunction function)
+        {
+            _output = output;
+            _function = function;
+        }
+
+        public Either<RfcErrorInfo, Unit> Reply(Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
+        {
+            return replyFunc(_output, Prelude.Right(_function)).Map(_ => Unit.Default);
+        }
+    }
+}

--- a/src/YaNco.Core/Connection.cs
+++ b/src/YaNco.Core/Connection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Dbosoft.Functional;
@@ -57,14 +58,6 @@ namespace Dbosoft.YaNco
                                     return (handle, result);
 
                                 }
-                            }
-
-                            case AllowStartOfProgramsMessage allowStartOfProgramsMessage:
-                            {
-                                var result = rfcRuntime.AllowStartOfPrograms(handle,
-                                    allowStartOfProgramsMessage.Callback).Map(u => (object)u);
-                                return (handle, result) ;
-
                             }
 
                             case DisposeMessage disposeMessage:
@@ -165,8 +158,12 @@ namespace Dbosoft.YaNco
         public EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function, CancellationToken cancellationToken) 
             => _stateAgent.Tell(new InvokeFunctionMessage(function, cancellationToken)).ToAsync().Map(_ => Unit.Default);
 
-        public EitherAsync<RfcErrorInfo, Unit> AllowStartOfPrograms(StartProgramDelegate callback) =>
-            _stateAgent.Tell(new AllowStartOfProgramsMessage(callback)).ToAsync().Map(r => Unit.Default);
+        [Obsolete("Use method WithStartProgramCallback of ConnectionBuilder instead. This method will be removed in next major release.")]
+        [ExcludeFromCodeCoverage]
+        public EitherAsync<RfcErrorInfo, Unit> AllowStartOfPrograms(StartProgramDelegate callback)
+        {
+            return RfcRuntime.AllowStartOfPrograms(_connectionHandle, callback).ToAsync();
+        }
 
         public EitherAsync<RfcErrorInfo, ConnectionAttributes> GetAttributes()
         {
@@ -200,15 +197,6 @@ namespace Dbosoft.YaNco
             }
         }
 
-        private class AllowStartOfProgramsMessage : AgentMessage
-        {
-            public readonly StartProgramDelegate Callback;
-
-            public AllowStartOfProgramsMessage(StartProgramDelegate callback)
-            {
-                Callback = callback;
-            }
-        }
 
         private class DisposeMessage : AgentMessage
         {

--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -4,6 +4,9 @@ using LanguageExt;
 
 namespace Dbosoft.YaNco
 {
+    /// <summary>
+    /// This class is used to build connections to a SAP ABAP backend.  
+    /// </summary>
     public class ConnectionBuilder
     {
         private readonly IDictionary<string, string> _connectionParam;
@@ -16,17 +19,39 @@ namespace Dbosoft.YaNco
             Func<CalledFunction, Either<RfcErrorInfo, Unit>>)> _functionHandlers
             = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)>();
 
+        /// <summary>
+        /// Creates a new connection builder. 
+        /// </summary>
+        /// <param name="connectionParam">Dictionary of connection parameters</param>
         public ConnectionBuilder(IDictionary<string, string> connectionParam)
         {
             _connectionParam = connectionParam;
         }
 
+        /// <summary>
+        /// Registers a action to configure the <see cref="IRfcRuntime"/>
+        /// </summary>
+        /// <param name="configure">action with <see cref="RfcRuntimeConfigurer"/></param>
+        /// <returns>current instance for chaining.</returns>
+        /// <remarks>
+        /// Multiple calls of this method will override the previous configuration action. 
+        /// </remarks>
         public ConnectionBuilder ConfigureRuntime(Action<RfcRuntimeConfigurer> configure)
         {
             _configureRuntime = configure;
             return this;
         }
 
+        /// <summary>
+        /// This method registers a callback of type <see cref="StartProgramDelegate"/> 
+        /// to handle backend requests to start local programs.
+        /// </summary>
+        /// <remarks>
+        /// The SAP backend can call function RFC_START_PROGRAM on back destination to request
+        /// clients to start local programs. This is used a lot in KPRO applications to start saphttp and sapftp.
+        /// </remarks>
+        /// <param name="startProgramDelegate">Delegate to callback function implementation.</param>
+        /// <returns>current instance for chaining</returns>
         public ConnectionBuilder WithStartProgramCallback(StartProgramDelegate startProgramDelegate)
         {
             return WithFunctionHandler("RFC_START_PROGRAM", builder => builder
@@ -38,6 +63,19 @@ namespace Dbosoft.YaNco
             );
         }
 
+        /// <summary>
+        /// This method registers a function handler from a SAP function name. 
+        /// </summary>
+        /// <param name="functionName">Name of function</param>
+        /// <param name="calledFunc">function handler</param>
+        /// <returns>current instance for chaining</returns>
+        /// <remarks>
+        /// The metadata of the function is retrieved from the backend. Therefore the function
+        /// must exists on the SAP backend system.
+        /// To register a generic function use the signature that builds from a <see cref="IFunctionBuilder"/>.
+        /// Function handlers are registered process wide (in the SAP NW RFC Library).
+        /// Multiple registrations of same function and same backend id will therefore override previous registrations.
+        /// </remarks>
         public ConnectionBuilder WithFunctionHandler(string functionName,
             Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
         {
@@ -45,6 +83,20 @@ namespace Dbosoft.YaNco
             return this;
         }
 
+        /// <summary>
+        /// This method registers a function handler from a <see cref="IFunctionBuilder"/>
+        /// </summary>
+        /// <param name="functionName">Name of function</param>
+        /// <param name="configureBuilder">action to configure function builder</param>
+        /// <param name="calledFunc">function handler</param>
+        /// <returns>current instance for chaining</returns>
+        /// <remarks>
+        /// The metadata of the function is build in the <see cref="IFunctionBuilder"/>. This allows to register
+        /// any kind of function. 
+        /// To register a known function use the signature with function name <seealso cref="WithFunctionHandler(string,System.Func{Dbosoft.YaNco.CalledFunction,LanguageExt.Either{Dbosoft.YaNco.RfcErrorInfo,LanguageExt.Unit}})"/>
+        /// Function handlers are registered process wide (in the SAP NW RFC Library) and mapped to backend system id. 
+        /// Multiple registrations of same function and same backend id will therefore override previous registrations.
+        /// </remarks>
         public ConnectionBuilder WithFunctionHandler(string functionName,
             Action<IFunctionBuilder> configureBuilder,
             Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
@@ -53,6 +105,13 @@ namespace Dbosoft.YaNco
             return this;
         }
 
+        /// <summary>
+        /// Use a alternative factory method to create connection. 
+        /// </summary>
+        /// <param name="factory">factory method</param>
+        /// <returns>current instance for chaining.</returns
+        /// <remarks>The default implementation call <see cref="Connection.Create"/>.
+        /// </remarks>
         public ConnectionBuilder UseFactory(
             Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo, IConnection>> factory)
         {
@@ -60,6 +119,15 @@ namespace Dbosoft.YaNco
             return this;
         }
 
+        /// <summary>
+        /// This method Builds the connection function from the <see cref="ConnectionBuilder"/> settings.
+        /// </summary>
+        /// <returns>current instance for chaining.</returns>
+        /// <remarks>
+        /// The connection builder first creates RfcRuntime and calls any registered runtime configure action.
+        /// The result is a function that first calls the connection factory (defaults to <seealso cref="Connection.Create"/>
+        /// and afterwards registers function handlers.
+        /// </remarks>
         public Func<EitherAsync<RfcErrorInfo, IConnection>> Build()
         {
             var runtimeConfigurer = new RfcRuntimeConfigurer();

--- a/src/YaNco.Core/DataContainer.cs
+++ b/src/YaNco.Core/DataContainer.cs
@@ -47,7 +47,12 @@ namespace Dbosoft.YaNco
         {
             return _rfcRuntime.GetTable(_handle, name).Map(handle => (ITable) new Table(handle, _rfcRuntime));
         }
-        
+
+        public Either<RfcErrorInfo, ITypeDescriptionHandle> GetTypeDescription()
+        {
+            return _rfcRuntime.GetTypeDescription(_handle);
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/YaNco.Core/Delegates.cs
+++ b/src/YaNco.Core/Delegates.cs
@@ -1,0 +1,4 @@
+﻿using Dbosoft.YaNco;
+using LanguageExt;
+
+public delegate Either<RfcErrorInfo, Unit> RfcFunctionDelegate(IRfcHandle rfcHandle, IFunctionHandle functionHandle);

--- a/src/YaNco.Core/FunctionBuilder.cs
+++ b/src/YaNco.Core/FunctionBuilder.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dbosoft.YaNco.Internal;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public class FunctionBuilder : IFunctionBuilder
+    {
+        private readonly string _functionName;
+        private readonly IDictionary<string, RfcParameterDescription> _parameters = new Dictionary<string, RfcParameterDescription>();
+        private readonly IRfcRuntime _runtime;
+
+
+        public FunctionBuilder(IRfcRuntime runtime, string functionName)
+        {
+            _runtime = runtime;
+            _functionName = functionName;
+        }
+
+        public IFunctionBuilder AddParameter(RfcParameterDescription parameter)
+        {
+            _parameters.Add(parameter.Name, parameter);
+            return this;
+        }
+
+        public IFunctionBuilder AddChar(string name, RfcDirection direction, uint length, bool optional = true, string defaultValue = null)
+        {
+            return AddParameter(new RfcParameterDescription(name, RfcType.CHAR, direction, length, length * 2, 0, optional, defaultValue));
+        }
+
+        public IFunctionBuilder AddInt(string name, RfcDirection direction, bool optional = true, int defaultValue = 0)
+        {
+            return AddParameter(new RfcParameterDescription(name, RfcType.INT, direction, 0, 0, 0, optional, defaultValue.ToString()));
+        }
+
+        public IFunctionBuilder AddLong(string name, RfcDirection direction, bool optional = true, long defaultValue = 0)
+        {
+            return AddParameter(new RfcParameterDescription(name, RfcType.INT8, direction, 0, 0, 0, optional, defaultValue.ToString()));
+        }
+
+        public IFunctionBuilder AddString(string name, RfcDirection direction, bool optional = true, uint length = 0, string defaultValue = null)
+        {
+            return AddParameter(new RfcParameterDescription(name, RfcType.STRING, direction, length, length * 2, 0, optional, defaultValue));
+        }
+
+        public IFunctionBuilder AddStructure(string name, RfcDirection direction, ITypeDescriptionHandle typeHandle, bool optional = true)
+        {
+            return AddTyped(name, RfcType.STRUCTURE, direction, typeHandle, optional);
+        }
+
+        public IFunctionBuilder AddStructure(string name, RfcDirection direction, IStructure structure, bool optional = true)
+        {
+            return structure.GetTypeDescription()
+                .Match(
+                    Right: r => AddTyped(name, RfcType.STRUCTURE, direction, r, optional),
+                    Left: l => throw new ArgumentException("Argument is not a valid type handle", nameof(structure)));
+        }
+
+        public IFunctionBuilder AddTable(string name, RfcDirection direction, ITable table, bool optional = true)
+        {
+            return table.GetTypeDescription()
+                .Match(
+                    Right: r => AddTyped(name, RfcType.STRUCTURE, direction, r, optional),
+                    Left: l => throw new ArgumentException("Argument is not a valid type handle", nameof(table)));
+        }
+
+        public IFunctionBuilder AddTable(string name, RfcDirection direction, ITypeDescriptionHandle typeHandle, bool optional = true)
+        {
+            return AddTyped(name, RfcType.TABLE, direction, typeHandle, optional);
+        }
+
+        private IFunctionBuilder AddTyped(string name, RfcType type, RfcDirection direction, ITypeDescriptionHandle typeHandle, bool optional = true)
+        {
+            if (!(typeHandle is TypeDescriptionHandle handle))
+                throw new ArgumentException("Argument has to be of type TypeDescriptionHandle", nameof(typeHandle));
+
+            var ptr = handle.Ptr;
+            return AddParameter(new RfcParameterDescription(name, type, direction, 0, 0, 0, optional, null) { TypeDescriptionHandle = ptr });
+        }
+
+        public Either<RfcErrorInfo, IFunctionDescriptionHandle> Build()
+        {
+
+            return _runtime.CreateFunctionDescription(_functionName).Bind(functionHandle =>
+            {
+                return _parameters.Values.Map(parameter =>
+                        _runtime.AddFunctionParameter(functionHandle, parameter))
+                    .Traverse(l => l).Map(e => functionHandle);
+
+            });
+
+        }
+
+    }
+
+}

--- a/src/YaNco.Core/FunctionalServerExtensions.cs
+++ b/src/YaNco.Core/FunctionalServerExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using LanguageExt;
+// ReSharper disable InconsistentNaming
+
+namespace Dbosoft.YaNco
+{
+    public static class FunctionalServerExtensions
+    {
+
+        public static Either<RfcErrorInfo, FunctionProcessed<TOutput>> Process<TInput, TOutput>(
+            this Either<RfcErrorInfo, FunctionInput<TInput>> input,
+            Func<TInput, TOutput> processFunc)
+        {
+            return input.Map(i => i.Process(processFunc));
+        }
+
+        public static Either<RfcErrorInfo, FunctionProcessed<Unit>> Process<TInput>(
+            this Either<RfcErrorInfo, FunctionInput<TInput>> input,
+            Action<TInput> processAction)
+        {
+            return input.Map(i =>
+            {
+                var (function, input1) = i;
+                processAction(input1);
+                return new FunctionProcessed<Unit>(Unit.Default, function);
+            });
+        }
+
+        public static Either<RfcErrorInfo, Unit> Reply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self, Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
+        {
+            return self.Bind(p => p.Reply(replyFunc));
+        }
+
+        public static Either<RfcErrorInfo, Unit> NoReply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self)
+        {
+            return self.Bind(p => p.Reply((o, f) => f));
+        }
+
+
+
+    }
+}

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using LanguageExt;
 
 namespace Dbosoft.YaNco.Internal
 {
@@ -40,6 +42,13 @@ namespace Dbosoft.YaNco.Internal
             var rc = Interopt.RfcGetConnectionAttributes(connectionHandle.Ptr, out var rfcAttributes, out errorInfo);
             attributes = rfcAttributes.ToConnectionAttributes();
             return rc;
+        }
+
+        public static FunctionDescriptionHandle CreateFunctionDescription(string functionName,
+            out RfcErrorInfo errorInfo)
+        {
+            var ptr = Interopt.RfcCreateFunctionDesc(functionName, out errorInfo);
+            return ptr == IntPtr.Zero ? null : new FunctionDescriptionHandle(ptr);
         }
 
         public static FunctionDescriptionHandle GetFunctionDescription(FunctionHandle functionHandle,
@@ -104,6 +113,24 @@ namespace Dbosoft.YaNco.Internal
             return ptr == IntPtr.Zero ? null : new FunctionHandle(ptr);
 
         }
+
+        public static RfcRc AddFunctionParameter(FunctionDescriptionHandle descriptionHandle, RfcParameterDescription parameterDescription, out RfcErrorInfo errorInfo)
+        {
+            var parameterDesc = new Interopt.RFC_PARAMETER_DESC
+            {
+                Name = parameterDescription.Name,
+                Type = parameterDescription.Type,
+                Direction = parameterDescription.Direction,
+                Optional = parameterDescription.Optional ? 'X' : ' ',
+                Decimals = parameterDescription.Decimals,
+                NucLength = parameterDescription.NucLength,
+                UcLength = parameterDescription.UcLength,
+                TypeDescHandle = parameterDescription.TypeDescriptionHandle
+            };
+
+            return Interopt.RfcAddParameter(descriptionHandle.Ptr, ref parameterDesc, out errorInfo);
+        }
+
 
         public static RfcRc GetFunctionParameterCount(FunctionDescriptionHandle descriptionHandle, out int count,
             out RfcErrorInfo errorInfo)
@@ -171,64 +198,112 @@ namespace Dbosoft.YaNco.Internal
             return ptr == IntPtr.Zero ? null : new TableHandle(ptr, true);
         }
 
+        public static RfcRc RegisterServerFunctionHandler(string sysId, FunctionDescriptionHandle functionDescription,
+            RfcFunctionDelegate functionHandler, out RfcErrorInfo errorInfo)
+        {
+            var rc = Interopt.RfcInstallServerFunction(sysId, functionDescription.Ptr, RFC_Function_Handler,
+                out errorInfo);
+            if (rc != RfcRc.RFC_OK)
+            {
+                return rc;
+            }
+
+            RegisteredFunctions.AddOrUpdate(functionDescription.Ptr, functionHandler, (c, v) => v);
+            return rc;
+        }
+
+        private static readonly object AllowStartOfProgramsLock = new object();
+
+        [Obsolete("Use method AllowStartOfPrograms of ConnectionBuilder. This method will be removed in next major release.")]
         public static void AllowStartOfPrograms(ConnectionHandle connectionHandle, StartProgramDelegate callback, out
             RfcErrorInfo errorInfo)
         {
-            var descriptionHandle = new FunctionDescriptionHandle(Interopt.RfcCreateFunctionDesc("RFC_START_PROGRAM", out errorInfo));
-            if (descriptionHandle.Ptr == IntPtr.Zero)
+            lock (AllowStartOfProgramsLock)
             {
-                return;
+
+                GetConnectionAttributes(connectionHandle, out var attributes, out errorInfo);
+                if (errorInfo.Code != RfcRc.RFC_OK)
+                    return;
+
+
+                RfcErrorInfo errorInfoLocal = default;
+                //function runtime is not available at this API level => as workaround create a new runtime -> in FunctionBuilder it is 
+                //only used to wrap this API implementation.
+                new FunctionBuilder(new RfcRuntime(), "RFC_START_PROGRAM")
+                    .AddChar("COMMAND", RfcDirection.Import, 512)
+                    .Build()
+                    .Match(funcDescriptionHandle =>
+                    {
+                        RegisterServerFunctionHandler(attributes.SystemId, funcDescriptionHandle as FunctionDescriptionHandle,
+                            (_, funcHandle) =>
+                            {
+                                var functionHandle = funcHandle as FunctionHandle;
+                                Debug.Assert(functionHandle != null, nameof(functionHandle) + " != null");
+
+                                var commandBuffer = new char[513];
+                                var rc = Interopt.RfcGetStringByIndex(functionHandle.Ptr, 0, commandBuffer,
+                                    (uint)commandBuffer.Length - 1, out var commandLength, out var error);
+
+                                if (rc != RfcRc.RFC_OK)
+                                    return Unit.Default;
+
+                                var command = new string(commandBuffer, 0, (int)commandLength);
+                                error = callback(command);
+
+                                if (error.Code == RfcRc.RFC_OK)
+                                    return Unit.Default;
+
+                                return error;
+                            }, out errorInfoLocal);
+                    }, l => errorInfoLocal = l);
+
+                errorInfo = errorInfoLocal;
             }
 
-            var paramDesc = new Interopt.RFC_PARAMETER_DESC { Name = "COMMAND", Type = RfcType.CHAR, Direction = RfcDirection.Import, NucLength = 512, UcLength = 1024 };
-            var rc = Interopt.RfcAddParameter(descriptionHandle.Ptr, ref paramDesc, out errorInfo);
-            if (rc != RfcRc.RFC_OK)
-            {
-                return;
-            }
-
-            rc = Interopt.RfcInstallServerFunction(null, descriptionHandle.Ptr, StartProgramHandler, out errorInfo);
-            if (rc != RfcRc.RFC_OK)
-            {
-                return;
-            }
-
-            RegisteredCallbacks.AddOrUpdate(connectionHandle.Ptr, callback, (c,v) => v );
-            
         }
 
-        private static readonly ConcurrentDictionary<IntPtr, StartProgramDelegate> RegisteredCallbacks 
-            = new ConcurrentDictionary<IntPtr, StartProgramDelegate>();
+        private static readonly ConcurrentDictionary<IntPtr, RfcFunctionDelegate> RegisteredFunctions
+            = new ConcurrentDictionary<IntPtr, RfcFunctionDelegate>();
 
-        private static readonly Interopt.RfcServerFunction StartProgramHandler = RFC_START_PROGRAM_Handler;
-
-        static RfcRc RFC_START_PROGRAM_Handler(IntPtr rfcHandle, IntPtr funcHandle, out RfcErrorInfo errorInfo)
+        private static RfcRc RFC_Function_Handler(IntPtr rfcHandle, IntPtr funcHandle, out RfcErrorInfo errorInfo)
         {
-            if (!RegisteredCallbacks.TryGetValue(rfcHandle, out var startProgramDelegate))
+            var descriptionHandle = Interopt.RfcDescribeFunction(funcHandle, out errorInfo);
+            if (descriptionHandle == IntPtr.Zero)
+                return errorInfo.Code;
+
+
+            if (!RegisteredFunctions.TryGetValue(descriptionHandle, out var functionDelegate))
             {
-                errorInfo = new RfcErrorInfo(RfcRc.RFC_INVALID_HANDLE, RfcErrorGroup.EXTERNAL_APPLICATION_FAILURE, "", 
-                    "no connection registered for this callback", "", "", "", "", "", "", "");
+                Interopt.RfcGetFunctionName(descriptionHandle, out var funcName, out _);
+                if (string.IsNullOrWhiteSpace(funcName))
+                    funcName = "[unknown function]";
+
+                errorInfo = new RfcErrorInfo(RfcRc.RFC_INVALID_HANDLE, RfcErrorGroup.EXTERNAL_APPLICATION_FAILURE, "",
+                    $"no function handler registered for function '{funcName}'", "", "", "", "", "", "", "");
                 return RfcRc.RFC_INVALID_HANDLE;
 
             }
-            
-            var commandBuffer = new char[513];
 
-            var rc = Interopt.RfcGetStringByIndex(funcHandle, 0, commandBuffer, (uint)commandBuffer.Length - 1, out var commandLength, out errorInfo);
+            RfcErrorInfo errorInfoLocal = default;
+            var rc = functionDelegate(new RfcHandle(rfcHandle), new FunctionHandle(funcHandle)).Match(
+                Right: r => RfcRc.RFC_OK,
+                l =>
+                {
+                    errorInfoLocal = l;
+                    return l.Code;
 
-            if (rc != RfcRc.RFC_OK)
-                return rc;
+                });
 
-            var command = new string(commandBuffer, 0, (int)commandLength);
-            errorInfo = startProgramDelegate(command);
+            errorInfo = errorInfoLocal;
+            return rc;
 
-            return errorInfo.Code;
         }
 
-
+        [Obsolete("Callback handlers are no longer bound to connection. This method will do nothing and will be removed in next major release.")]
+        // ReSharper disable once UnusedParameter.Global
         public static void RemoveCallbackHandler(IntPtr connectionHandle)
         {
-            RegisteredCallbacks.TryRemove(connectionHandle, out var _);
+
         }
 
         public static RfcRc GetTableRowCount(TableHandle table, out int count, out RfcErrorInfo errorInfo)

--- a/src/YaNco.Core/Internal/RfcHandle.cs
+++ b/src/YaNco.Core/Internal/RfcHandle.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Dbosoft.YaNco.Internal
+{
+    public class RfcHandle : IRfcHandle
+    {
+        internal IntPtr Ptr { get; set; }
+
+        internal RfcHandle(IntPtr ptr)
+        {
+            Ptr = ptr;
+        }
+    }
+}

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -32,6 +32,12 @@ namespace Dbosoft.YaNco
 
         public RfcRuntimeOptions Options { get; }
 
+
+        public bool IsFunctionHandlerRegistered(string sysId, string functionName)
+        {
+            return Api.IsFunctionHandlerRegistered(sysId, functionName);
+        }
+
         private Either<RfcErrorInfo, TResult> ResultOrError<TResult>(TResult result, RfcErrorInfo errorInfo, bool logAsError = false)
         {
             if (result == null || errorInfo.Code != RfcRc.RFC_OK)
@@ -197,15 +203,22 @@ namespace Dbosoft.YaNco
 
         }
 
-        public Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, IFunction function, Func<IFunction, Either<RfcErrorInfo, Unit>> handler)
+        public Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, 
+            string functionName,
+            IFunction function, Func<IFunction, Either<RfcErrorInfo, Unit>> handler)
         {
             return GetFunctionDescription(function.Handle)
-                .Use(used => used.Bind(d => AddFunctionHandler(sysid, d, handler)));
+                .Use(used => used.Bind(d => AddFunctionHandler(sysid,
+                    functionName, d, handler)));
         }
 
-        public Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, IFunctionDescriptionHandle descriptionHandle, Func<IFunction, Either<RfcErrorInfo, Unit>> handler)
+        public Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, 
+            string functionName,
+            IFunctionDescriptionHandle descriptionHandle, Func<IFunction, Either<RfcErrorInfo, Unit>> handler)
         {
-            Api.RegisterServerFunctionHandler(sysid, descriptionHandle as FunctionDescriptionHandle,
+            Api.RegisterServerFunctionHandler(sysid,
+                functionName, 
+                descriptionHandle as FunctionDescriptionHandle,
                 (rfcHandle, functionHandle) =>
                 {
                     var func = new Function(functionHandle, this);

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -270,7 +270,7 @@ namespace Dbosoft.YaNco
 
         }
 
-        [Obsolete("Use method AllowStartOfPrograms of ConnectionBuilder. This method will be removed in next major release.")]
+        [Obsolete("Use method WithStartProgramCallback of ConnectionBuilder. This method will be removed in next major release.")]
         public Either<RfcErrorInfo, Unit> AllowStartOfPrograms(IConnectionHandle connectionHandle,
             StartProgramDelegate callback)
         {

--- a/src/YaNco.Primitives/RfcParameterDescription.cs
+++ b/src/YaNco.Primitives/RfcParameterDescription.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Dbosoft.YaNco
+{
+    public class RfcParameterDescription : RfcParameterInfo
+    {
+        public IntPtr TypeDescriptionHandle { get; set; }
+
+        public RfcParameterDescription(string name, RfcType type, RfcDirection direction, uint nucLength, uint ucLength, uint decimals, bool optional, string defaultValue) : base(name, type, direction, nucLength, ucLength, decimals, defaultValue, null, optional)
+        {
+        }
+    }
+}

--- a/src/YaNco.Primitives/RfcParameterInfo.cs
+++ b/src/YaNco.Primitives/RfcParameterInfo.cs
@@ -42,5 +42,4 @@
             Decimals = decimals;
         }
     }
-
 }

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -67,21 +67,31 @@ namespace SAPSystemTests
                 .ConfigureRuntime(c =>
                     c.WithLogger(new SimpleConsoleLogger()));
 
-            using (var context = new RfcContext(connectionBuilder.Build()))
+            var connectionFunc = connectionBuilder.Build();
+
+            using (var context = new RfcContext(connectionFunc))
             {
                 await context.PingAsync();
 
                 await context.GetConnection().Bind(c => c.GetAttributes())
                     .IfRight(attributes =>
-                    { 
+                    {
                         Console.WriteLine("connection attributes:");
                         Console.WriteLine(JsonConvert.SerializeObject(attributes));
                     });
 
                 await RunIntegrationTests(context);
+            }
 
+
+            using (var context = new RfcContext(connectionFunc))
+            {
                 long totalTest1 = 0;
                 long totalTest2 = 0;
+
+                //second call back test (should still be called)
+                await RunCallbackTest(context);
+
 
                 for (var run = 0; run < repeats; run++)
                 {

--- a/test/SAPSystemTests/Properties/launchSettings.json
+++ b/test/SAPSystemTests/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SAPSystemTests": {
       "commandName": "Project",
-      "commandLineArgs": "/tests:repeats=100000 /tests:rows=0",
+      "commandLineArgs": "/tests:repeats=10 /tests:rows=100",
       "nativeDebugging": true
     }
   }

--- a/test/SAPSystemTests/SimpleConsoleLogger.cs
+++ b/test/SAPSystemTests/SimpleConsoleLogger.cs
@@ -20,7 +20,7 @@ namespace SAPSystemTests
 
         public void LogTrace(string message, object data)
         {
-            //Console.WriteLine($"TRACE\t{message}{ObjectToString(data)}");
+           // Console.WriteLine($"TRACE\t{message}{ObjectToString(data)}");
         }
 
         public void LogError(string message, object data)
@@ -30,6 +30,9 @@ namespace SAPSystemTests
 
         public void LogDebug(string message, object data)
         {
+            if (data is RfcErrorInfo { Key: "RFC_TABLE_MOVE_EOF" })
+                return;
+
             Console.WriteLine($"DEBUG\t{message}{ObjectToString(data)}");
         }
 

--- a/test/YaNco.Core.Tests/ConnectionTests.cs
+++ b/test/YaNco.Core.Tests/ConnectionTests.cs
@@ -136,24 +136,5 @@ namespace YaNco.Core.Tests
             rfcRuntimeMock.VerifyAll();
         }
 
-
-        [Fact]
-        public async Task AllowStartOfPrograms_is_cancelled()
-        {
-            var rfcRuntimeMock = new Mock<IRfcRuntime>()
-                .SetupOpenConnection(out var connHandle);
-
-            StartProgramDelegate callback = (c) => RfcErrorInfo.Ok();
-
-            rfcRuntimeMock.Setup(r => r
-                    .AllowStartOfPrograms(connHandle.Object,callback))
-                    .Returns(Unit.Default);
-
-            var conn = await rfcRuntimeMock.CreateConnection()
-                .Map(c => c.AllowStartOfPrograms(callback));
-
-            rfcRuntimeMock.VerifyAll();
-
-        }
     }
 }

--- a/test/YaNco.Core.Tests/YaNco.Core.Tests.csproj
+++ b/test/YaNco.Core.Tests/YaNco.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net471;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net471;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Implemented client side function handler registration.
With this PR clients can register function handlers either from a known function (metadata lookup from backend) or by building function metadata at runtime. 
The function handlers can be registered in the ConnectionBuilder (method WithFunctionHandler) .
Refactored WithStartProgramCallback of ConnectionBuilder to build RFC_START_PROGRAM as function handler.

AllowStartOfProgram methods on RFcRuntime and Connection are obsolete now and should be removed with next major release. 
