### PR TITLE
Rfc Server

### DIFF
--- a/YaNco.sln
+++ b/YaNco.sln
@@ -42,7 +42,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaNco.Core.Tests", "test\Ya
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CreateSalesOrder", "samples\netcore3.1\CreateSalesOrder\CreateSalesOrder.csproj", "{6CFC3765-314B-45A4-B8B8-1728159E1B91}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YaNco.Hosting", "samples\YaNco.Hosting\YaNco.Hosting.csproj", "{A07C8033-2F41-4406-88A9-286FABE0B615}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaNco.Hosting", "samples\YaNco.Hosting\YaNco.Hosting.csproj", "{A07C8033-2F41-4406-88A9-286FABE0B615}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RfcServerTest", "test\RfcServerTest\RfcServerTest.csproj", "{95D62E71-C281-47F1-ADD3-BD362B12B48A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -98,6 +100,10 @@ Global
 		{A07C8033-2F41-4406-88A9-286FABE0B615}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A07C8033-2F41-4406-88A9-286FABE0B615}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A07C8033-2F41-4406-88A9-286FABE0B615}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95D62E71-C281-47F1-ADD3-BD362B12B48A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95D62E71-C281-47F1-ADD3-BD362B12B48A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95D62E71-C281-47F1-ADD3-BD362B12B48A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95D62E71-C281-47F1-ADD3-BD362B12B48A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -114,6 +120,7 @@ Global
 		{11F3C75F-E6B7-4A7B-92C9-16CB36F054AA} = {EF91385F-FDE0-4CB5-9CED-DF2977ADA833}
 		{6CFC3765-314B-45A4-B8B8-1728159E1B91} = {BEE8F8E1-8859-4A61-B668-5467423911D7}
 		{A07C8033-2F41-4406-88A9-286FABE0B615} = {D81DD87D-D96B-4A06-B360-B71BED6E5199}
+		{95D62E71-C281-47F1-ADD3-BD362B12B48A} = {EF91385F-FDE0-4CB5-9CED-DF2977ADA833}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C3AB2171-471F-4842-A039-4CE0AC4FBB45}

--- a/YaNco.sln.DotSettings
+++ b/YaNco.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Abap/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dbosoft/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=sysid/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/samples/WebApi.Shared/APIResultExtensions.cs
+++ b/samples/WebApi.Shared/APIResultExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Threading.Tasks;
 using Dbosoft.YaNco;
 using LanguageExt;
@@ -6,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace WebApi
 {
+    [ExcludeFromCodeCoverage]
     public static class ApiResultExtensions
     {
         public static Task<IActionResult> ToActionResult<T>(this EitherAsync<RfcErrorInfo, T> result)

--- a/samples/WebApi.Shared/ApiModel/CompanyModel.cs
+++ b/samples/WebApi.Shared/ApiModel/CompanyModel.cs
@@ -1,5 +1,8 @@
-﻿namespace WebApi.ApiModel
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace WebApi.ApiModel
 {
+    [ExcludeFromCodeCoverage]
     public class CompanyModel
     {
         public string Code { get; set; }

--- a/samples/WebApi.Shared/CompanyExtensions.cs
+++ b/samples/WebApi.Shared/CompanyExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Dbosoft.YaNco;
 using LanguageExt;
@@ -8,6 +9,7 @@ using WebApi.ApiModel;
 
 namespace WebApi.Shared
 {
+    [ExcludeFromCodeCoverage]
     public static class CompanyExtensions
     {
         public static EitherAsync<RfcErrorInfo, IEnumerable<CompanyModel>> GetCompanies(this IRfcContext rfcContext)

--- a/samples/YaNco.Hosting/RfcLibraryHelper.cs
+++ b/samples/YaNco.Hosting/RfcLibraryHelper.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Dbosoft.YaNco.Hosting
 {
+    [ExcludeFromCodeCoverage]
     public static class RfcLibraryHelper
     {
         /// <summary>

--- a/samples/YaNco.Hosting/RfcLoggingAdapter.cs
+++ b/samples/YaNco.Hosting/RfcLoggingAdapter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -7,6 +8,7 @@ using Newtonsoft.Json;
 
 namespace Dbosoft.YaNco.Hosting
 {
+    [ExcludeFromCodeCoverage]
     public class RfcLoggingAdapter : ILogger
     {
         private readonly Microsoft.Extensions.Logging.ILogger _logger;

--- a/samples/YaNco.Hosting/SAPConnectionFactory.cs
+++ b/samples/YaNco.Hosting/SAPConnectionFactory.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Dbosoft.YaNco.TypeMapping;
 using LanguageExt;
 using Microsoft.Extensions.Configuration;
 
 namespace Dbosoft.YaNco.Hosting
 {
+    [ExcludeFromCodeCoverage]
     public class SAPConnectionFactory
     {
         private readonly IConfiguration _configuration;

--- a/samples/YaNco.Hosting/YaNcoServiceCollectionExtensions.cs
+++ b/samples/YaNco.Hosting/YaNcoServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Dbosoft.YaNco;
 using Dbosoft.YaNco.Hosting;
 using Dbosoft.YaNco.TypeMapping;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 // ReSharper disable once CheckNamespace
 namespace YaNco.Hosting
 {
+    [ExcludeFromCodeCoverage]
     public static class YaNcoServiceCollectionExtensions
     {
 

--- a/samples/netcore2.1/SAPWebAPI/Controllers/CompanyController.cs
+++ b/samples/netcore2.1/SAPWebAPI/Controllers/CompanyController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using Dbosoft.YaNco;
 using WebApi;
@@ -8,6 +9,7 @@ namespace SAPWebAPI.Controllers
 {
     [ApiController]
     [Route("api/[Controller]")]
+    [ExcludeFromCodeCoverage]
     public class CompanyController : ControllerBase
     {
         private readonly IRfcContext _rfcContext;

--- a/samples/netcore2.1/SAPWebAPI/Program.cs
+++ b/samples/netcore2.1/SAPWebAPI/Program.cs
@@ -1,4 +1,5 @@
-﻿using Dbosoft.YaNco.Hosting;
+﻿using System.Diagnostics.CodeAnalysis;
+using Dbosoft.YaNco.Hosting;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using WebApi;
@@ -6,6 +7,7 @@ using YaNco.Hosting;
 
 namespace SAPWebAPI
 {
+    [ExcludeFromCodeCoverage]
     public class Program
     {
         public static void Main(string[] args)

--- a/samples/netcore2.1/SAPWebAPI/Startup.cs
+++ b/samples/netcore2.1/SAPWebAPI/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -7,6 +8,7 @@ using YaNco.Hosting;
 
 namespace SAPWebAPI
 {
+    [ExcludeFromCodeCoverage]
     public class Startup
     {
         public Startup(IConfiguration configuration)

--- a/samples/netcore3.1/CreateSalesOrder/CreateSimpleSalesDocument.cs
+++ b/samples/netcore3.1/CreateSalesOrder/CreateSimpleSalesDocument.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Dbosoft.YaNco;
@@ -9,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace CreateSalesOrder
 {
+    [ExcludeFromCodeCoverage]
     public class CreateSimpleSalesDocument : RootCommand
     {
         public CreateSimpleSalesDocument()

--- a/samples/netcore3.1/CreateSalesOrder/CustomizingSettings.cs
+++ b/samples/netcore3.1/CreateSalesOrder/CustomizingSettings.cs
@@ -1,8 +1,11 @@
-﻿namespace CreateSalesOrder
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace CreateSalesOrder
 {
     /// <summary>
     /// Settings from configuration, should be used in Bind call to salesSettings.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     internal class CustomizingSettings
     {
         public string DocumentType { get; set; }

--- a/samples/netcore3.1/CreateSalesOrder/Program.cs
+++ b/samples/netcore3.1/CreateSalesOrder/Program.cs
@@ -2,11 +2,13 @@
 using System.CommandLine.Builder;
 using System.CommandLine.Hosting;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using YaNco.Hosting;
 
 namespace CreateSalesOrder
 {
+    [ExcludeFromCodeCoverage]
     internal class Program
     {
         // ReSharper disable once ArrangeTypeMemberModifiers

--- a/samples/netcore3.1/CreateSalesOrder/TableReturnExtensions.cs
+++ b/samples/netcore3.1/CreateSalesOrder/TableReturnExtensions.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Dbosoft.YaNco;
 using LanguageExt;
 
 namespace CreateSalesOrder
 {
+    [ExcludeFromCodeCoverage]
     internal static class TableReturnExtensions
     {
         /// <summary>

--- a/samples/netcore3.1/SAPWebAPI/Controllers/CompanyController.cs
+++ b/samples/netcore3.1/SAPWebAPI/Controllers/CompanyController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using Dbosoft.YaNco;
 using WebApi;
@@ -6,6 +7,7 @@ using WebApi.Shared;
 
 namespace SAPWebAPI.Controllers
 {
+    [ExcludeFromCodeCoverage]
     [ApiController]
     [Route("api/{Controller}")]
     public class CompanyController : ControllerBase

--- a/samples/netcore3.1/SAPWebAPI/Program.cs
+++ b/samples/netcore3.1/SAPWebAPI/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Dbosoft.YaNco.Hosting;
@@ -12,6 +13,7 @@ using YaNco.Hosting;
 
 namespace SAPWebAPI
 {
+    [ExcludeFromCodeCoverage]
     public class Program
     {
         public static void Main(string[] args)

--- a/samples/netcore3.1/SAPWebAPI/Startup.cs
+++ b/samples/netcore3.1/SAPWebAPI/Startup.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -7,6 +8,7 @@ using YaNco.Hosting;
 
 namespace SAPWebAPI
 {
+    [ExcludeFromCodeCoverage]
     public class Startup
     {
         public Startup(IConfiguration configuration)

--- a/src/YaNco.Abstractions/IRfcRuntime.cs
+++ b/src/YaNco.Abstractions/IRfcRuntime.cs
@@ -22,10 +22,10 @@ namespace Dbosoft.YaNco
         Either<RfcErrorInfo, RfcParameterInfo> GetFunctionParameterDescription(IFunctionDescriptionHandle descriptionHandle, int index);
         Either<RfcErrorInfo, RfcParameterInfo> GetFunctionParameterDescription(IFunctionDescriptionHandle descriptionHandle, string name);
         Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, 
-            string functionName, IFunction function, Func<IFunction, Either<RfcErrorInfo, Unit>> handler);
+            string functionName, IFunction function, Func<IFunction, EitherAsync<RfcErrorInfo, Unit>> handler);
         Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, string functionName, 
             IFunctionDescriptionHandle descriptionHandle,
-            Func<IFunction, Either<RfcErrorInfo, Unit>> handler);
+            Func<IFunction, EitherAsync<RfcErrorInfo, Unit>> handler);
         Either<RfcErrorInfo, IStructureHandle> GetStructure(IDataContainerHandle dataContainer, string name);
         Either<RfcErrorInfo, ITableHandle> GetTable(IDataContainerHandle dataContainer, string name);
         Either<RfcErrorInfo, ITableHandle> CloneTable(ITableHandle tableHandle);

--- a/src/YaNco.Abstractions/IRfcRuntime.cs
+++ b/src/YaNco.Abstractions/IRfcRuntime.cs
@@ -67,6 +67,11 @@ namespace Dbosoft.YaNco
 
         RfcRuntimeOptions Options { get; }
         bool IsFunctionHandlerRegistered(string sysId, string functionName);
+
+        Either<RfcErrorInfo, IRfcServerHandle> CreateServer(IDictionary<string, string> connectionParams);
+        Either<RfcErrorInfo, Unit> LaunchServer(IRfcServerHandle rfcServerHandle);
+        Either<RfcErrorInfo, Unit> ShutdownServer(IRfcServerHandle rfcServerHandle, int timeout);
+
     }
 
 

--- a/src/YaNco.Abstractions/IRfcServer.cs
+++ b/src/YaNco.Abstractions/IRfcServer.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public interface IRfcServer : IDisposable
+    {
+        bool Disposed { get; }
+        IRfcRuntime RfcRuntime { get; }
+        EitherAsync<RfcErrorInfo, Unit> Start();
+        EitherAsync<RfcErrorInfo, Unit> Stop(int timeout = 0);
+    }
+}

--- a/src/YaNco.Abstractions/IRfcServer.cs
+++ b/src/YaNco.Abstractions/IRfcServer.cs
@@ -9,5 +9,7 @@ namespace Dbosoft.YaNco
         IRfcRuntime RfcRuntime { get; }
         EitherAsync<RfcErrorInfo, Unit> Start();
         EitherAsync<RfcErrorInfo, Unit> Stop(int timeout = 0);
+        Unit AddConnectionFactory(Func<EitherAsync<RfcErrorInfo, IConnection>> connectionFactory);
+        Func<EitherAsync<RfcErrorInfo, IConnection>> ClientConnection { get;  }
     }
 }

--- a/src/YaNco.Abstractions/IRfcServerHandle.cs
+++ b/src/YaNco.Abstractions/IRfcServerHandle.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Dbosoft.YaNco
+{
+    public interface IRfcServerHandle : IDisposable
+    {
+
+    }
+}

--- a/src/YaNco.Core/CalledFunction.cs
+++ b/src/YaNco.Core/CalledFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using LanguageExt;
 
 namespace Dbosoft.YaNco
@@ -45,6 +46,13 @@ namespace Dbosoft.YaNco
         {
             return new FunctionProcessed<TOutput>(processFunc(Input), Function);
         }
+
+        public async Task<FunctionProcessed<TOutput>> ProcessAsync<TOutput>(Func<TInput, Task<TOutput>> processFunc)
+        {
+            return new FunctionProcessed<TOutput>(await processFunc(Input), Function);
+        }
+
+
 
         public void Deconstruct(out IFunction function, out TInput input)
         {

--- a/src/YaNco.Core/CalledFunction.cs
+++ b/src/YaNco.Core/CalledFunction.cs
@@ -6,10 +6,12 @@ namespace Dbosoft.YaNco
     public readonly struct CalledFunction
     {
         public readonly IFunction Function;
+        private readonly Func<IRfcContext> _rfcContextFunc;
 
-        internal CalledFunction(IFunction function)
+        internal CalledFunction(IFunction function, Func<IRfcContext> rfcContextFunc)
         {
             Function = function;
+            _rfcContextFunc = rfcContextFunc;
         }
 
         public Either<RfcErrorInfo, FunctionInput<TInput>> Input<TInput>(Func<Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, TInput>> inputFunc)
@@ -18,6 +20,13 @@ namespace Dbosoft.YaNco
             return inputFunc(Prelude.Right(function)).Map(input => new FunctionInput<TInput>(input, function));
         }
 
+        public T UseRfcContext<T>(Func<IRfcContext, T> mapFunc)
+        {
+            using (var rfcContext = _rfcContextFunc())
+            {
+                return mapFunc(rfcContext);
+            }
+        }
 
     }
 

--- a/src/YaNco.Core/CalledFunction.cs
+++ b/src/YaNco.Core/CalledFunction.cs
@@ -15,6 +15,12 @@ namespace Dbosoft.YaNco
             _rfcContextFunc = rfcContextFunc;
         }
 
+        /// <summary>
+        /// Input processing for a called function. Use this method to extract values from the rfc function.
+        /// </summary>
+        /// <typeparam name="TInput">Type of data extracted from function. Could be any type.</typeparam>
+        /// <param name="inputFunc">Function to map from RFC function to the desired input type</param>
+        /// <returns><see cref="FunctionInput{TInput}"/> wrapped in a <see cref="Either{L,R}"/> </returns>
         public Either<RfcErrorInfo, FunctionInput<TInput>> Input<TInput>(Func<Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, TInput>> inputFunc)
         {
             var function = Function;
@@ -42,10 +48,24 @@ namespace Dbosoft.YaNco
             Function = function;
         }
 
+        /// <summary>
+        /// Data processing for a called function. Use this method to do any work you would like to do when the function is called.
+        /// </summary>
+        /// <typeparam name="TOutput">Type of data returned from processing. Could be any type.</typeparam>
+        /// <param name="processFunc">Function to map from <typeparamref name="TInput"></typeparamref> to <typeparam name="TOutput"></typeparam>"/></param>
+        /// <returns><see cref="FunctionProcessed{TOutput}"/></returns>
+
         public FunctionProcessed<TOutput> Process<TOutput>(Func<TInput, TOutput> processFunc)
         {
             return new FunctionProcessed<TOutput>(processFunc(Input), Function);
         }
+
+        /// <summary>
+        /// Async data processing for a called function. Use this method to do any work you would like to do when the function is called.
+        /// </summary>
+        /// <typeparam name="TOutput">Type of data returned from processing. Could be any type.</typeparam>
+        /// <param name="processFunc">Function to map from <typeparamref name="TInput"></typeparamref> to <typeparam name="TOutput"></typeparam>"/></param>
+        /// <returns><see cref="FunctionProcessed{TOutput}"/> wrapped in a Task</returns>
 
         public async Task<FunctionProcessed<TOutput>> ProcessAsync<TOutput>(Func<TInput, Task<TOutput>> processFunc)
         {

--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -16,8 +16,8 @@ namespace Dbosoft.YaNco
             _connectionFactory = Connection.Create;
 
         readonly List<(string, Action<IFunctionBuilder>,
-            Func<CalledFunction, Either<RfcErrorInfo, Unit>>)> _functionHandlers
-            = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)>();
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)> _functionHandlers
+            = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)>();
 
         private Func<EitherAsync<RfcErrorInfo, IConnection>> _buildFunction;
 
@@ -79,7 +79,7 @@ namespace Dbosoft.YaNco
         /// Multiple registrations of same function and same backend id will therefore have no effect.
         /// </remarks>
         public ConnectionBuilder WithFunctionHandler(string functionName,
-            Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
         {
             _functionHandlers.Add((functionName, null, calledFunc));
             return this;
@@ -101,7 +101,7 @@ namespace Dbosoft.YaNco
         /// </remarks>
         public ConnectionBuilder WithFunctionHandler(string functionName,
             Action<IFunctionBuilder> configureBuilder,
-            Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
         {
             _functionHandlers.Add((functionName, configureBuilder, calledFunc));
             return this;

--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -1,23 +1,20 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using LanguageExt;
 
 namespace Dbosoft.YaNco
 {
     /// <summary>
-    /// This class is used to build connections to a SAP ABAP backend.  
+    /// This class is used to build client connections to a SAP ABAP backend.  
     /// </summary>
-    public class ConnectionBuilder
+    public class ConnectionBuilder : RfcBuilderBase<ConnectionBuilder>
     {
         private readonly IDictionary<string, string> _connectionParam;
-        private Action<RfcRuntimeConfigurer> _configureRuntime = (c) => { };
 
         private Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo, IConnection>>
             _connectionFactory = Connection.Create;
 
-        readonly List<(string, Action<IFunctionBuilder>,
-            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)> _functionHandlers
-            = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)>();
 
         private Func<EitherAsync<RfcErrorInfo, IConnection>> _buildFunction;
 
@@ -27,43 +24,10 @@ namespace Dbosoft.YaNco
         /// <param name="connectionParam">Dictionary of connection parameters</param>
         public ConnectionBuilder(IDictionary<string, string> connectionParam)
         {
-            _connectionParam = connectionParam;
+            _connectionParam = connectionParam.ToDictionary(kv => kv.Key.ToUpperInvariant(), kv => kv.Value);
+            Self = this;
         }
 
-        /// <summary>
-        /// Registers a action to configure the <see cref="IRfcRuntime"/>
-        /// </summary>
-        /// <param name="configure">action with <see cref="RfcRuntimeConfigurer"/></param>
-        /// <returns>current instance for chaining.</returns>
-        /// <remarks>
-        /// Multiple calls of this method will override the previous configuration action. 
-        /// </remarks>
-        public ConnectionBuilder ConfigureRuntime(Action<RfcRuntimeConfigurer> configure)
-        {
-            _configureRuntime = configure;
-            return this;
-        }
-
-        /// <summary>
-        /// This method registers a callback of type <see cref="StartProgramDelegate"/> 
-        /// to handle backend requests to start local programs.
-        /// </summary>
-        /// <remarks>
-        /// The SAP backend can call function RFC_START_PROGRAM on back destination to request
-        /// clients to start local programs. This is used a lot in KPRO applications to start saphttp and sapftp.
-        /// </remarks>
-        /// <param name="startProgramDelegate">Delegate to callback function implementation.</param>
-        /// <returns>current instance for chaining</returns>
-        public ConnectionBuilder WithStartProgramCallback(StartProgramDelegate startProgramDelegate)
-        {
-            return WithFunctionHandler("RFC_START_PROGRAM", builder => builder
-                    .AddChar("COMMAND", RfcDirection.Import, 512),
-                cf => cf
-                    .Input(f => f.GetField<string>("COMMAND"))
-                    .Process(cmd => startProgramDelegate(cmd))
-                    .NoReply()
-            );
-        }
 
         /// <summary>
         /// This method registers a function handler from a SAP function name. 
@@ -75,37 +39,16 @@ namespace Dbosoft.YaNco
         /// The metadata of the function is retrieved from the backend. Therefore the function
         /// must exists on the SAP backend system.
         /// To register a generic function use the signature that builds from a <see cref="IFunctionBuilder"/>.
-        /// Function handlers are registered process wide (in the SAP NW RFC Library).and mapped to backend system id. 
-        /// Multiple registrations of same function and same backend id will therefore have no effect.
-        /// </remarks>
-        public ConnectionBuilder WithFunctionHandler(string functionName,
-            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
-        {
-            _functionHandlers.Add((functionName, null, calledFunc));
-            return this;
-        }
-
-        /// <summary>
-        /// This method registers a function handler from a <see cref="IFunctionBuilder"/>
-        /// </summary>
-        /// <param name="functionName">Name of function</param>
-        /// <param name="configureBuilder">action to configure function builder</param>
-        /// <param name="calledFunc">function handler</param>
-        /// <returns>current instance for chaining</returns>
-        /// <remarks>
-        /// The metadata of the function is build in the <see cref="IFunctionBuilder"/>. This allows to register
-        /// any kind of function. 
-        /// To register a known function use the signature with function name <seealso cref="WithFunctionHandler(string,System.Func{Dbosoft.YaNco.CalledFunction,LanguageExt.Either{Dbosoft.YaNco.RfcErrorInfo,LanguageExt.Unit}})"/>
         /// Function handlers are registered process wide (in the SAP NW RFC Library) and mapped to backend system id. 
         /// Multiple registrations of same function and same backend id will therefore have no effect.
         /// </remarks>
         public ConnectionBuilder WithFunctionHandler(string functionName,
-            Action<IFunctionBuilder> configureBuilder,
             Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
         {
-            _functionHandlers.Add((functionName, configureBuilder, calledFunc));
+            FunctionHandlers.Add((functionName, null, calledFunc));
             return this;
         }
+
 
         /// <summary>
         /// Use a alternative factory method to create connection. 
@@ -135,11 +78,7 @@ namespace Dbosoft.YaNco
             if(_buildFunction != null)
                 return _buildFunction;
             
-            var runtimeConfigurer = new RfcRuntimeConfigurer();
-            _configureRuntime(runtimeConfigurer);
-            var runtime = runtimeConfigurer.Create();
-
-            _buildFunction = () => _connectionFactory(_connectionParam, runtime)
+            _buildFunction = () => _connectionFactory(_connectionParam, CreateRfcRuntime())
                 .Bind(RegisterFunctionHandlers);
 
             return _buildFunction;
@@ -150,7 +89,7 @@ namespace Dbosoft.YaNco
         {
             return connection.GetAttributes().Bind(attributes =>
             {
-                return _functionHandlers.Map(reg =>
+                return FunctionHandlers.Map(reg =>
                 {
                     var (functionName, configureBuilder, callBackFunction) = reg;
 
@@ -181,6 +120,83 @@ namespace Dbosoft.YaNco
                     });
                 }).Traverse(l => l).Map(eu => connection);
             });
+        }
+    }
+
+    public class RfcBuilderBase<TBuilder>
+    {
+        private Action<RfcRuntimeConfigurer> _configureRuntime = (c) => { };
+        protected TBuilder Self { get; set; }
+
+        protected readonly List<(string, Action<IFunctionBuilder>,
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)> FunctionHandlers
+            = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)>();
+
+
+        /// <summary>
+        /// Registers a action to configure the <see cref="IRfcRuntime"/>
+        /// </summary>
+        /// <param name="configure">action with <see cref="RfcRuntimeConfigurer"/></param>
+        /// <returns>current instance for chaining.</returns>
+        /// <remarks>
+        /// Multiple calls of this method will override the previous configuration action. 
+        /// </remarks>
+        public TBuilder ConfigureRuntime(Action<RfcRuntimeConfigurer> configure)
+        {
+            _configureRuntime = configure;
+            return Self;
+        }
+
+        /// <summary>
+        /// This method registers a callback of type <see cref="StartProgramDelegate"/> 
+        /// to handle backend requests to start local programs.
+        /// </summary>
+        /// <remarks>
+        /// The SAP backend can call function RFC_START_PROGRAM on back destination to request
+        /// clients to start local programs. This is used a lot in KPRO applications to start saphttp and sapftp.
+        /// </remarks>
+        /// <param name="startProgramDelegate">Delegate to callback function implementation.</param>
+        /// <returns>current instance for chaining</returns>
+        public TBuilder WithStartProgramCallback(StartProgramDelegate startProgramDelegate)
+        {
+            return WithFunctionHandler("RFC_START_PROGRAM", builder => builder
+                    .AddChar("COMMAND", RfcDirection.Import, 512),
+                cf => cf
+                    .Input(f => f.GetField<string>("COMMAND"))
+                    .Process(cmd => startProgramDelegate(cmd))
+                    .NoReply()
+            );
+        }
+
+        /// <summary>
+        /// This method registers a function handler from a <see cref="IFunctionBuilder"/>
+        /// </summary>
+        /// <param name="functionName">Name of function</param>
+        /// <param name="configureBuilder">action to configure function builder</param>
+        /// <param name="calledFunc">function handler</param>
+        /// <returns>current instance for chaining</returns>
+        /// <remarks>
+        /// The metadata of the function is build in the <see cref="IFunctionBuilder"/>. This allows to register
+        /// any kind of function. 
+        /// To register a known function use the signature with function name <seealso cref="WithFunctionHandler(string,System.Func{Dbosoft.YaNco.CalledFunction,LanguageExt.Either{Dbosoft.YaNco.RfcErrorInfo,LanguageExt.Unit}})"/>
+        /// Function handlers are registered process wide (in the SAP NW RFC Library) and mapped to backend system id. 
+        /// Multiple registrations of same function and same backend id will therefore have no effect.
+        /// </remarks>
+        public TBuilder WithFunctionHandler(string functionName,
+            Action<IFunctionBuilder> configureBuilder,
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
+        {
+            FunctionHandlers.Add((functionName, configureBuilder, calledFunc));
+            return Self;
+        }
+
+
+        protected IRfcRuntime CreateRfcRuntime()
+        {
+            var runtimeConfigurer = new RfcRuntimeConfigurer();
+            _configureRuntime(runtimeConfigurer);
+            return runtimeConfigurer.Create();
+            
         }
     }
 }

--- a/src/YaNco.Core/ConnectionBuilder.cs
+++ b/src/YaNco.Core/ConnectionBuilder.cs
@@ -123,7 +123,7 @@ namespace Dbosoft.YaNco
         }
     }
 
-    public class RfcBuilderBase<TBuilder>
+    public abstract class RfcBuilderBase<TBuilder>
     {
         private Action<RfcRuntimeConfigurer> _configureRuntime = (c) => { };
         protected TBuilder Self { get; set; }

--- a/src/YaNco.Core/Delegates.cs
+++ b/src/YaNco.Core/Delegates.cs
@@ -1,4 +1,6 @@
-﻿using Dbosoft.YaNco;
-using LanguageExt;
+﻿using LanguageExt;
 
-public delegate EitherAsync<RfcErrorInfo, Unit> RfcFunctionDelegate(IRfcHandle rfcHandle, IFunctionHandle functionHandle);
+namespace Dbosoft.YaNco
+{
+    public delegate EitherAsync<RfcErrorInfo, Unit> RfcFunctionDelegate(IRfcHandle rfcHandle, IFunctionHandle functionHandle);
+}

--- a/src/YaNco.Core/Delegates.cs
+++ b/src/YaNco.Core/Delegates.cs
@@ -1,4 +1,4 @@
 ﻿using Dbosoft.YaNco;
 using LanguageExt;
 
-public delegate Either<RfcErrorInfo, Unit> RfcFunctionDelegate(IRfcHandle rfcHandle, IFunctionHandle functionHandle);
+public delegate EitherAsync<RfcErrorInfo, Unit> RfcFunctionDelegate(IRfcHandle rfcHandle, IFunctionHandle functionHandle);

--- a/src/YaNco.Core/FunctionalServerExtensions.cs
+++ b/src/YaNco.Core/FunctionalServerExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using LanguageExt;
 // ReSharper disable InconsistentNaming
 
@@ -25,7 +26,7 @@ namespace Dbosoft.YaNco
                 return new FunctionProcessed<Unit>(Unit.Default, function);
             });
         }
-
+        
         public static Either<RfcErrorInfo, Unit> Reply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self, Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
         {
             return self.Bind(p => p.Reply(replyFunc));
@@ -37,6 +38,24 @@ namespace Dbosoft.YaNco
         }
 
 
+        public static EitherAsync<RfcErrorInfo, IRfcServer> Start(this EitherAsync<RfcErrorInfo, IRfcServer> eitherServer)
+        {
+            return eitherServer.Bind(s => s.Start().Map(_ => s));
+        }
 
+        public static async Task<IRfcServer> StartOrException(this EitherAsync<RfcErrorInfo, IRfcServer> eitherServer)
+        {
+            var res = await eitherServer.Bind(s => s.Start()
+                    .Map(_ => s))
+                .MapLeft(l => l.Throw())
+                .ToEither();
+
+            return res.RightAsEnumerable().FirstOrDefault();
+        }
+
+        public static EitherAsync<RfcErrorInfo, IRfcServer> Stop(this EitherAsync<RfcErrorInfo, IRfcServer> eitherServer, int timeout = 0)
+        {
+            return eitherServer.Bind(s => s.Stop(timeout).Map(_ => s));
+        }
     }
 }

--- a/src/YaNco.Core/FunctionalServerExtensions.cs
+++ b/src/YaNco.Core/FunctionalServerExtensions.cs
@@ -15,6 +15,14 @@ namespace Dbosoft.YaNco
             return input.Map(i => i.Process(processFunc));
         }
 
+        public static EitherAsync<RfcErrorInfo, FunctionProcessed<TOutput>> ProcessAsync<TInput, TOutput>(
+            this Either<RfcErrorInfo, FunctionInput<TInput>> input,
+            Func<TInput, Task<TOutput>> processFunc)
+        {
+            return input.ToAsync()
+                .MapAsync(i => i.ProcessAsync(processFunc));
+        }
+
         public static Either<RfcErrorInfo, FunctionProcessed<Unit>> Process<TInput>(
             this Either<RfcErrorInfo, FunctionInput<TInput>> input,
             Action<TInput> processAction)
@@ -26,15 +34,20 @@ namespace Dbosoft.YaNco
                 return new FunctionProcessed<Unit>(Unit.Default, function);
             });
         }
-        
-        public static Either<RfcErrorInfo, Unit> Reply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self, Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
+
+        public static EitherAsync<RfcErrorInfo, Unit> Reply<TOutput>(this EitherAsync<RfcErrorInfo, FunctionProcessed<TOutput>> self, Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
         {
-            return self.Bind(p => p.Reply(replyFunc));
+            return self.Bind(p => p.Reply(replyFunc).ToAsync());
         }
 
-        public static Either<RfcErrorInfo, Unit> NoReply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self)
+        public static EitherAsync<RfcErrorInfo, Unit> Reply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self, Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
         {
-            return self.Bind(p => p.Reply((o, f) => f));
+            return self.Bind(p => p.Reply(replyFunc)).ToAsync();
+        }
+
+        public static EitherAsync<RfcErrorInfo, Unit> NoReply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self)
+        {
+            return self.Bind(p => p.Reply((o, f) => f)).ToAsync();
         }
 
 

--- a/src/YaNco.Core/FunctionalServerExtensions.cs
+++ b/src/YaNco.Core/FunctionalServerExtensions.cs
@@ -7,7 +7,14 @@ namespace Dbosoft.YaNco
 {
     public static class FunctionalServerExtensions
     {
-
+        /// <summary>
+        /// Data processing for a called function. Use this method to do any work you would like to do when the function is called.
+        /// </summary>
+        /// <typeparam name="TOutput">Type of data returned from processing. Could be any type.</typeparam>
+        /// <typeparam name="TInput">Type of data returned from rfc input. Could be any type.</typeparam>
+        /// <param name="input">input from previous chain step.</param>
+        /// <param name="processFunc">Function to map from <typeparamref name="TInput"></typeparamref> to <typeparam name="TOutput"></typeparam>"/></param>
+        /// <returns><see cref="FunctionProcessed{TOutput}"/></returns>
         public static Either<RfcErrorInfo, FunctionProcessed<TOutput>> Process<TInput, TOutput>(
             this Either<RfcErrorInfo, FunctionInput<TInput>> input,
             Func<TInput, TOutput> processFunc)
@@ -15,6 +22,14 @@ namespace Dbosoft.YaNco
             return input.Map(i => i.Process(processFunc));
         }
 
+        /// <summary>
+        /// Async data processing for a called function. Use this method to do any work you would like to do when the function is called.
+        /// </summary>
+        /// <typeparam name="TOutput">Type of data returned from processing. Could be any type.</typeparam>
+        /// <typeparam name="TInput">Type of data returned from rfc input. Could be any type.</typeparam>
+        /// <param name="processFunc">Function to map from <typeparamref name="TInput"></typeparamref> to <typeparam name="TOutput"></typeparam>"/></param>
+        /// <param name="input">input from previous chain step.</param>
+        /// <returns><see cref="FunctionProcessed{TOutput}"/></returns>
         public static EitherAsync<RfcErrorInfo, FunctionProcessed<TOutput>> ProcessAsync<TInput, TOutput>(
             this Either<RfcErrorInfo, FunctionInput<TInput>> input,
             Func<TInput, Task<TOutput>> processFunc)
@@ -23,6 +38,13 @@ namespace Dbosoft.YaNco
                 .MapAsync(i => i.ProcessAsync(processFunc));
         }
 
+        /// <summary>
+        /// Data processing for a called function. Use this method to do any work you would like to do when the function is called.
+        /// </summary>
+        /// <typeparam name="TInput">Type of data returned from rfc input. Could be any type.</typeparam>
+        /// <param name="input">input from previous chain step.</param>
+        /// <param name="processAction">Action to process <typeparamref name="TInput"></typeparamref>.</param>
+        /// <returns><see cref="FunctionProcessed{Unit}"/>"/></returns>
         public static Either<RfcErrorInfo, FunctionProcessed<Unit>> Process<TInput>(
             this Either<RfcErrorInfo, FunctionInput<TInput>> input,
             Action<TInput> processAction)
@@ -35,27 +57,71 @@ namespace Dbosoft.YaNco
             });
         }
 
-        public static EitherAsync<RfcErrorInfo, Unit> Reply<TOutput>(this EitherAsync<RfcErrorInfo, FunctionProcessed<TOutput>> self, Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
+        /// <summary>
+        /// Use this method to send a response to sap backend after processing the function call.
+        /// </summary>
+        /// <typeparam name="TOutput">type of Output of processing chain step.</typeparam>
+        /// <param name="self">previous chain step</param>
+        /// <param name="replyFunc">Function to map from <typeparam name="TOutput"/> to rfc function.</param>
+        /// <returns></returns>
+        public static EitherAsync<RfcErrorInfo, Unit> Reply<TOutput>(this EitherAsync<RfcErrorInfo, FunctionProcessed<TOutput>> self, 
+            Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
         {
             return self.Bind(p => p.Reply(replyFunc).ToAsync());
         }
 
-        public static EitherAsync<RfcErrorInfo, Unit> Reply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self, Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
+        /// <summary>
+        /// Use this method to send a response to sap backend after processing the function call.
+        /// </summary>
+        /// <typeparam name="TOutput">type of Output of processing chain step.</typeparam>
+        /// <param name="self">previous chain step</param>
+        /// <param name="replyFunc">Function to map from <typeparam name="TOutput"/> to rfc function.</param>
+        /// <returns><see cref="Unit"/> wrapped in a <see cref="EitherAsync{RfcErrorInfo,Unit}"/></returns>
+        public static EitherAsync<RfcErrorInfo, Unit> Reply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self, 
+            Func<TOutput, Either<RfcErrorInfo, IFunction>, Either<RfcErrorInfo, IFunction>> replyFunc)
         {
             return self.Bind(p => p.Reply(replyFunc)).ToAsync();
         }
 
+        /// <summary>
+        /// Use this method to end the function call chain without sending a response back to SAP backend.
+        /// </summary>
+        /// <typeparam name="TOutput">type of Output of processing chain step.</typeparam>
+        /// <param name="self">previous chain step</param>
+        /// <returns><see cref="Unit"/> wrapped in a <see cref="EitherAsync{RfcErrorInfo,Unit}"/></returns>
         public static EitherAsync<RfcErrorInfo, Unit> NoReply<TOutput>(this Either<RfcErrorInfo, FunctionProcessed<TOutput>> self)
         {
             return self.Bind(p => p.Reply((o, f) => f)).ToAsync();
         }
 
+        /// <summary>
+        /// Use this method to end the function call chain without sending a response back to SAP backend.
+        /// </summary>
+        /// <typeparam name="TOutput">type of Output of processing chain step.</typeparam>
+        /// <param name="self">previous chain step</param>
+        /// <returns><see cref="Unit"/> wrapped in a <see cref="EitherAsync{RfcErrorInfo,Unit}"/></returns>
+        public static EitherAsync<RfcErrorInfo, Unit> NoReply<TOutput>(this EitherAsync<RfcErrorInfo, FunctionProcessed<TOutput>> self)
+        {
+            return self.Bind(p => p.Reply((o, f) => f).ToAsync());
+        }
 
+        /// <summary>
+        /// Starts a RFC Server
+        /// </summary>
+        /// <param name="eitherServer">RFC Server, wrapping in a <see cref="EitherAsync{RfcErrorInfo,IRfcServer}"/></param>
+        /// <returns>started RFC Server, wrapping in a <see cref="EitherAsync{RfcErrorInfo,IRfcServer}"/></returns>
         public static EitherAsync<RfcErrorInfo, IRfcServer> Start(this EitherAsync<RfcErrorInfo, IRfcServer> eitherServer)
         {
             return eitherServer.Bind(s => s.Start().Map(_ => s));
         }
 
+        /// <summary>
+        /// Starts a RFC Server or throws a <see cref="RfcErrorException"/> if start failed.
+        /// </summary>
+        /// <param name="eitherServer">RFC Server, wrapping in a <see cref="EitherAsync{RfcErrorInfo,IRfcServer}"/></param>
+        /// <returns>Started RFC Server if Either is not left. Otherwise a exception will be thrown.</returns>
+        /// <remarks>Use this method to integrate the <see cref="IRfcServer"/> with services that expect exceptions on failure.</remarks>
+        /// <exception cref="RfcErrorException"></exception>
         public static async Task<IRfcServer> StartOrException(this EitherAsync<RfcErrorInfo, IRfcServer> eitherServer)
         {
             var res = await eitherServer.Bind(s => s.Start()
@@ -66,6 +132,12 @@ namespace Dbosoft.YaNco
             return res.RightAsEnumerable().FirstOrDefault();
         }
 
+        /// <summary>
+        /// Stops a RFC Server
+        /// </summary>
+        /// <param name="eitherServer">RFC Server, wrapping in a <see cref="EitherAsync{RfcErrorInfo,IRfcServer}"/></param>
+        /// <param name="timeout">Timeout for stopping the rfc server</param>
+        /// <returns>Stopped RFC Server, wrapping in a <see cref="EitherAsync{RfcErrorInfo,IRfcServer}"/></returns>
         public static EitherAsync<RfcErrorInfo, IRfcServer> Stop(this EitherAsync<RfcErrorInfo, IRfcServer> eitherServer, int timeout = 0)
         {
             return eitherServer.Bind(s => s.Stop(timeout).Map(_ => s));

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading.Tasks;
 using LanguageExt;
 
 namespace Dbosoft.YaNco.Internal
@@ -339,7 +340,10 @@ namespace Dbosoft.YaNco.Internal
                     errorInfoLocal = l;
                     return l.Code;
 
-                });
+                })
+                .ConfigureAwait(true)
+                .GetAwaiter().GetResult();
+                
 
             errorInfo = errorInfoLocal;
             return rc;

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -121,11 +121,14 @@ namespace Dbosoft.YaNco.Internal
                 Name = parameterDescription.Name,
                 Type = parameterDescription.Type,
                 Direction = parameterDescription.Direction,
-                Optional = parameterDescription.Optional ? 'X' : ' ',
+                Optional = parameterDescription.Optional ? 'X' : '\0',
                 Decimals = parameterDescription.Decimals,
                 NucLength = parameterDescription.NucLength,
                 UcLength = parameterDescription.UcLength,
-                TypeDescHandle = parameterDescription.TypeDescriptionHandle
+                TypeDescHandle = parameterDescription.TypeDescriptionHandle,
+                ExtendedDescription = IntPtr.Zero,
+                ParameterText = parameterDescription.ParameterText ?? "",
+                DefaultValue = parameterDescription.DefaultValue
             };
 
             return Interopt.RfcAddParameter(descriptionHandle.Ptr, ref parameterDesc, out errorInfo);
@@ -500,20 +503,20 @@ namespace Dbosoft.YaNco.Internal
 
 
 
-        private struct FunctionRegistration: IEquatable<FunctionRegistration>
+        private readonly struct FunctionRegistration: IEquatable<FunctionRegistration>
         {
-            public readonly string SysId;
-            public readonly string Name;
+            private readonly string _sysId;
+            private readonly string _name;
 
             public FunctionRegistration(string sysId, string name)
             {
-                SysId = sysId;
-                Name = name;
+                _sysId = sysId;
+                _name = name;
             }
 
             public bool Equals(FunctionRegistration other)
             {
-                return SysId == other.SysId && Name == other.Name;
+                return _sysId == other._sysId && _name == other._name;
             }
 
             public override bool Equals(object obj)
@@ -525,7 +528,7 @@ namespace Dbosoft.YaNco.Internal
             {
                 unchecked
                 {
-                    return (SysId.GetHashCode() * 397) ^ Name.GetHashCode();
+                    return (_sysId.GetHashCode() * 397) ^ _name.GetHashCode();
                 }
             }
         }

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -174,6 +174,26 @@ namespace Dbosoft.YaNco.Internal
             return Interopt.RfcCancel(connectionHandle.Ptr, out errorInfo);
         }
 
+        public static RfcRc LaunchServer(RfcServerHandle serverHandle, out RfcErrorInfo errorInfo)
+        {
+            return Interopt.RfcLaunchServer(serverHandle.Ptr, out errorInfo);
+        }
+
+        public static RfcRc ShutdownServer(RfcServerHandle serverHandle, int timeout, out RfcErrorInfo errorInfo)
+        {
+            return Interopt.RfcShutdownServer(serverHandle.Ptr, (uint)timeout, out errorInfo);
+        }
+
+        public static RfcServerHandle CreateServer(IDictionary<string, string> connectionParams,
+            out RfcErrorInfo errorInfo)
+        {
+            var rfcOptions = connectionParams.Select(x => new Interopt.RfcConnectionParameter { Name = x.Key, Value = x.Value })
+                .ToArray();
+
+            var ptr = Interopt.RfcCreateServer(rfcOptions, (uint)rfcOptions.Length, out errorInfo);
+            return ptr == IntPtr.Zero ? null : new RfcServerHandle(ptr);
+        }
+
         public static RfcRc GetStructure(IDataContainerHandle dataContainer, string name,
             out StructureHandle structure, out RfcErrorInfo errorInfo)
         {

--- a/src/YaNco.Core/Internal/ConnectionHandle.cs
+++ b/src/YaNco.Core/Internal/ConnectionHandle.cs
@@ -2,11 +2,11 @@
 
 namespace Dbosoft.YaNco.Internal
 {
-    public class ConnectionHandle : IConnectionHandle
+    public class ConnectionHandle : RfcHandle, IConnectionHandle
     {
         internal IntPtr Ptr { get; private set; }
 
-        internal ConnectionHandle(IntPtr ptr)
+        internal ConnectionHandle(IntPtr ptr) : base(ptr)
         {
             Ptr = ptr;
         }
@@ -15,7 +15,6 @@ namespace Dbosoft.YaNco.Internal
         {
             if (Ptr == IntPtr.Zero) return;
 
-            Api.RemoveCallbackHandler(Ptr);
             Interopt.RfcCloseConnection(Ptr, out _);
             
             Ptr = IntPtr.Zero;

--- a/src/YaNco.Core/Internal/Interopt.cs
+++ b/src/YaNco.Core/Internal/Interopt.cs
@@ -13,21 +13,32 @@ namespace Dbosoft.YaNco.Internal
         public static extern RfcRc RfcGetVersion(out uint majorVersion, out uint minorVersion, out uint patchLevel);
 
 
-        [DllImport(SapNwRfcName)]
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
         public static extern IntPtr RfcOpenConnection(RfcConnectionParameter[] connectionParams, uint paramCount, out RfcErrorInfo errorInfo);
 
-        [DllImport(SapNwRfcName)]
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
         public static extern RfcRc RfcCloseConnection(IntPtr rfcHandle, out RfcErrorInfo errorInfo);
 
-        [DllImport(SapNwRfcName)]
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
         public static extern RfcRc RfcIsConnectionHandleValid(IntPtr rfcHandle, out int isValid, out RfcErrorInfo errorInfo);
 
         [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
         public static extern RfcRc RfcGetConnectionAttributes(IntPtr rfcHandle, out RfcAttributes attributes, out RfcErrorInfo errorInfo);
 
-        [DllImport(SapNwRfcName)]
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
         public static extern RfcRc RfcCancel(IntPtr rfcHandle, out RfcErrorInfo errorInfo);
 
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+        public static extern IntPtr RfcCreateServer(RfcConnectionParameter[] connectionParams, uint paramCount, out RfcErrorInfo errorInfo);
+
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+        public static extern RfcRc RfcDestroyServer(IntPtr rfcHandle, out RfcErrorInfo errorInfo);
+
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+        public static extern RfcRc RfcLaunchServer(IntPtr rfcHandle, out RfcErrorInfo errorInfo);
+
+        [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+        public static extern RfcRc RfcShutdownServer(IntPtr rfcHandle, uint timeout, out RfcErrorInfo errorInfo);
 
         [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
         public static extern IntPtr RfcGetFunctionDesc(IntPtr rfcHandle, string funcName, out RfcErrorInfo errorInfo);

--- a/src/YaNco.Core/Internal/Interopt.cs
+++ b/src/YaNco.Core/Internal/Interopt.cs
@@ -234,10 +234,10 @@ namespace Dbosoft.YaNco.Internal
             public IntPtr TypeDescHandle;
 
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 30 + 1)]
-            public readonly string DefaultValue;
+            public string DefaultValue;
 
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 79 + 1)]
-            public readonly string ParameterText;
+            public string ParameterText;
             public char Optional;
 
             public IntPtr ExtendedDescription;

--- a/src/YaNco.Core/Internal/RfcServerHandle.cs
+++ b/src/YaNco.Core/Internal/RfcServerHandle.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Dbosoft.YaNco.Internal
+{
+    public class RfcServerHandle : IRfcServerHandle
+    {
+        internal RfcServerHandle(IntPtr ptr)
+        {
+            Ptr = ptr;
+        }
+
+        public IntPtr Ptr { get; private set; }
+
+        public void Dispose()
+        {
+            if (Ptr == IntPtr.Zero) return;
+
+            Interopt.RfcDestroyServer(Ptr, out _);
+            Ptr = IntPtr.Zero;
+        }
+    }
+}

--- a/src/YaNco.Core/RfcMappingConfigurer.cs
+++ b/src/YaNco.Core/RfcMappingConfigurer.cs
@@ -1,36 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
-using Dbosoft.YaNco;
 using Dbosoft.YaNco.TypeMapping;
 
-public class RfcMappingConfigurer
+namespace Dbosoft.YaNco
 {
-    private Func<IEnumerable<Type>, IEnumerable<Type>,IFieldMapper>
-        _mappingFactory = RfcRuntime.CreateDefaultFieldMapper;
-
-    private readonly List<Type> _fromRfcMappingTypes = new List<Type>();
-    private readonly List<Type> _toRfcMappingTypes = new List<Type>();
-
-    public RfcMappingConfigurer UseFactory(Func<IEnumerable<Type>, IEnumerable<Type>, IFieldMapper> factory)
+    public class RfcMappingConfigurer
     {
-        _mappingFactory = factory;
-        return this;
-    }
+        private Func<IEnumerable<Type>, IEnumerable<Type>,IFieldMapper>
+            _mappingFactory = RfcRuntime.CreateDefaultFieldMapper;
 
-    public RfcMappingConfigurer AddToRfcMapper(Type mapper)
-    {
-        _toRfcMappingTypes.Add(mapper);
-        return this;
-    }
+        private readonly List<Type> _fromRfcMappingTypes = new List<Type>();
+        private readonly List<Type> _toRfcMappingTypes = new List<Type>();
 
-    public RfcMappingConfigurer AddFromRfcMapper(Type mapper)
-    {
-        _fromRfcMappingTypes.Add(mapper);
-        return this;
-    }
+        public RfcMappingConfigurer UseFactory(Func<IEnumerable<Type>, IEnumerable<Type>, IFieldMapper> factory)
+        {
+            _mappingFactory = factory;
+            return this;
+        }
 
-    internal IFieldMapper Create()
-    {
-        return _mappingFactory(_fromRfcMappingTypes, _toRfcMappingTypes);
+        public RfcMappingConfigurer AddToRfcMapper(Type mapper)
+        {
+            _toRfcMappingTypes.Add(mapper);
+            return this;
+        }
+
+        public RfcMappingConfigurer AddFromRfcMapper(Type mapper)
+        {
+            _fromRfcMappingTypes.Add(mapper);
+            return this;
+        }
+
+        internal IFieldMapper Create()
+        {
+            return _mappingFactory(_fromRfcMappingTypes, _toRfcMappingTypes);
+        }
     }
 }

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -237,7 +237,7 @@ namespace Dbosoft.YaNco
 
         public Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, 
             string functionName,
-            IFunction function, Func<IFunction, Either<RfcErrorInfo, Unit>> handler)
+            IFunction function, Func<IFunction, EitherAsync<RfcErrorInfo, Unit>> handler)
         {
             return GetFunctionDescription(function.Handle)
                 .Use(used => used.Bind(d => AddFunctionHandler(sysid,
@@ -246,7 +246,7 @@ namespace Dbosoft.YaNco
 
         public Either<RfcErrorInfo, Unit> AddFunctionHandler(string sysid, 
             string functionName,
-            IFunctionDescriptionHandle descriptionHandle, Func<IFunction, Either<RfcErrorInfo, Unit>> handler)
+            IFunctionDescriptionHandle descriptionHandle, Func<IFunction, EitherAsync<RfcErrorInfo, Unit>> handler)
         {
             Api.RegisterServerFunctionHandler(sysid,
                 functionName, 

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -38,6 +38,38 @@ namespace Dbosoft.YaNco
             return Api.IsFunctionHandlerRegistered(sysId, functionName);
         }
 
+        public Either<RfcErrorInfo, IRfcServerHandle> CreateServer(IDictionary<string, string> connectionParams)
+        {
+            if (connectionParams.Count == 0)
+                return new RfcErrorInfo(RfcRc.RFC_EXTERNAL_FAILURE,
+                    RfcErrorGroup.EXTERNAL_APPLICATION_FAILURE, RfcRc.RFC_EXTERNAL_FAILURE.ToString(),
+                    "Cannot open SAP connection with empty connection settings.",
+                    "", "", "", "", "", "", "");
+
+            var loggedParams = new Dictionary<string, string>(connectionParams);
+
+            Logger.IfSome(l => l.LogTrace("creating rfc server", loggedParams));
+            IRfcServerHandle handle = Api.CreateServer(connectionParams, out var errorInfo);
+            return ResultOrError(handle, errorInfo, true);
+
+        }
+
+        public Either<RfcErrorInfo, Unit> LaunchServer(IRfcServerHandle rfcServerHandle)
+        {
+            Logger.IfSome(l => l.LogTrace("starting rfc server", rfcServerHandle));
+            var rc = Api.LaunchServer(rfcServerHandle as RfcServerHandle, out var errorInfo);
+            return ResultOrError(Unit.Default, rc, errorInfo);
+
+        }
+
+        public Either<RfcErrorInfo, Unit> ShutdownServer(IRfcServerHandle rfcServerHandle, int timeout)
+        {
+            Logger.IfSome(l => l.LogTrace($"stopping rfc server with timeout of {timeout} seconds.", rfcServerHandle));
+            var rc = Api.ShutdownServer(rfcServerHandle as RfcServerHandle, timeout, out var errorInfo);
+            return ResultOrError(Unit.Default, rc, errorInfo);
+
+        }
+
         private Either<RfcErrorInfo, TResult> ResultOrError<TResult>(TResult result, RfcErrorInfo errorInfo, bool logAsError = false)
         {
             if (result == null || errorInfo.Code != RfcRc.RFC_OK)

--- a/src/YaNco.Core/RfcRuntimeConfigurer.cs
+++ b/src/YaNco.Core/RfcRuntimeConfigurer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Dbosoft.YaNco;
 using Dbosoft.YaNco.TypeMapping;
 
 namespace Dbosoft.YaNco
@@ -10,27 +9,48 @@ namespace Dbosoft.YaNco
             _runtimeFactory = (logger, mapper, options) => new RfcRuntime(logger, mapper, options);
 
         private ILogger _logger;
-        private RfcRuntimeOptions _options = new RfcRuntimeOptions();
+        private readonly RfcRuntimeOptions _options = new RfcRuntimeOptions();
         private Action<RfcMappingConfigurer> _configureMapping = (m) => { };
 
+        /// <summary>
+        /// Registers a <see cref="ILogger"/> implementation as logger in runtime.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <returns></returns>
         public RfcRuntimeConfigurer WithLogger(ILogger logger)
         {
             _logger = logger;
             return this;
         }
 
+        /// <summary>
+        /// Configures options for the created <see cref="IRfcRuntime"/>
+        /// </summary>
+        /// <param name="configure"></param>
+        /// <returns></returns>
         public RfcRuntimeConfigurer ConfigureOptions(Action<RfcRuntimeOptions> configure)
         {
             configure(_options);
             return this;
         }
 
+        /// <summary>
+        /// Configures type mapping of created <see cref="IRfcRuntime"/>
+        /// </summary>
+        /// <param name="configure"></param>
+        /// <returns></returns>
         public RfcRuntimeConfigurer ConfigureMapping(Action<RfcMappingConfigurer> configure)
         {
             _configureMapping = configure;
             return this;
         }
 
+        /// <summary>
+        /// Use a factory method to create the RFC runtime.
+        /// </summary>
+        /// <param name="factory">function of factory method</param>
+        /// <returns></returns>
+        /// <remarks>Use this method to override the creation of <see cref="IRfcRuntime"/>. For example for dependency injection.</remarks>
         public RfcRuntimeConfigurer UseFactory(Func<ILogger, IFieldMapper, RfcRuntimeOptions, IRfcRuntime> factory)
         {
             _runtimeFactory = factory;

--- a/src/YaNco.Core/RfcServer.cs
+++ b/src/YaNco.Core/RfcServer.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using Dbosoft.Functional;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public class RfcServer : IRfcServer
+    {
+        public IRfcRuntime RfcRuntime { get; }
+        private readonly IAgent<AgentMessage, Either<RfcErrorInfo, object>> _stateAgent;
+        public bool Disposed { get; private set; }
+
+        private RfcServer(IRfcServerHandle serverHandle, IRfcRuntime rfcRuntime)
+        {
+            RfcRuntime = rfcRuntime;
+
+            _stateAgent = Agent.Start<IRfcServerHandle, AgentMessage, Either<RfcErrorInfo, object>>(
+                serverHandle, (handle, msg) =>
+                {
+                    if (handle == null)
+                        return (null,
+                            new RfcErrorInfo(RfcRc.RFC_INVALID_HANDLE, RfcErrorGroup.EXTERNAL_RUNTIME_FAILURE,
+                                "", "Rfc Server already destroyed", "", "E", "", "", "", "", ""));
+
+                    try
+                    {
+                        switch (msg)
+                        {
+                            case LaunchServerMessage _:
+                            {
+                                var result = rfcRuntime.LaunchServer(handle);
+                                return (handle, result);
+
+                            }
+
+                            case ShutdownServerMessage shutdownServerMessage:
+                            {
+                                var result = rfcRuntime.ShutdownServer(
+                                    handle, shutdownServerMessage.Timeout);
+                                return (handle, result);
+
+                            }
+
+                            case DisposeMessage disposeMessage:
+                            {
+                                handle.Dispose();
+                                return (null, Prelude.Left(disposeMessage.ErrorInfo));
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        rfcRuntime.Logger.IfSome(l => l.LogException(ex));
+                    }
+
+                    throw new InvalidOperationException();
+                });
+
+        }
+
+        public static EitherAsync<RfcErrorInfo, IRfcServer> Create(
+            IDictionary<string, string> connectionParams, IRfcRuntime runtime)
+        {
+            return runtime.CreateServer(connectionParams).ToAsync().Map(handle => (IRfcServer)new RfcServer(handle, runtime));
+        }
+
+
+        public EitherAsync<RfcErrorInfo, Unit> Start()
+            => _stateAgent.Tell(new LaunchServerMessage()).ToAsync().Map(_ => Unit.Default);
+
+        public EitherAsync<RfcErrorInfo, Unit> Stop(int timeout = 0)
+            => _stateAgent.Tell(new ShutdownServerMessage(timeout)).ToAsync().Map(_ => Unit.Default);
+
+        private void ReleaseUnmanagedResources()
+        {
+            if (Disposed)
+                return;
+
+            Disposed = true;
+            _stateAgent.Tell(new DisposeMessage(RfcErrorInfo.EmptyResult()));
+        }
+
+        public void Dispose()
+        {
+            ReleaseUnmanagedResources();
+            GC.SuppressFinalize(this);
+        }
+
+        ~RfcServer()
+        {
+            ReleaseUnmanagedResources();
+        }
+
+        private class AgentMessage
+        {
+
+        }
+
+        private class LaunchServerMessage : AgentMessage
+        {
+
+        }
+
+        private class ShutdownServerMessage : AgentMessage
+        {
+            public int Timeout { get; }
+
+            public ShutdownServerMessage(int timeout)
+            {
+                Timeout = timeout;
+            }
+        }
+
+        private class DisposeMessage : AgentMessage
+        {
+            public readonly RfcErrorInfo ErrorInfo;
+
+            public DisposeMessage(RfcErrorInfo errorInfo)
+            {
+                ErrorInfo = errorInfo;
+            }
+        }
+
+    }
+}

--- a/src/YaNco.Core/RfcServerClientConfigurer.cs
+++ b/src/YaNco.Core/RfcServerClientConfigurer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public class RfcServerClientConfigurer
+    {
+        private readonly ConnectionBuilder _builder;
+
+        public RfcServerClientConfigurer(ConnectionBuilder builder)
+        {
+            _builder = builder;
+            
+        }
+
+        /// <summary>
+        /// This method registers a function handler from a SAP function name. 
+        /// </summary>
+        /// <param name="functionName">Name of function</param>
+        /// <param name="calledFunc">function handler</param>
+        /// <returns>current instance for chaining</returns>
+        /// <remarks>
+        /// The metadata of the function is retrieved from the backend. Therefore the function
+        /// must exists on the SAP backend system.
+        /// Function handlers are registered process wide (in the SAP NW RFC Library).and mapped to backend system id. 
+        /// Multiple registrations of same function and same backend id will therefore have no effect.
+        /// </remarks>
+        public RfcServerClientConfigurer WithFunctionHandler(string functionName,
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
+        {
+            _builder.WithFunctionHandler(functionName, calledFunc);
+            return this;
+        }
+
+    }
+}

--- a/src/YaNco.Core/RfcServerContext.cs
+++ b/src/YaNco.Core/RfcServerContext.cs
@@ -1,0 +1,141 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    internal class RfcServerContext : IRfcContext
+    {
+        private readonly IRfcServer _rfcServer;
+        private IRfcContext _currentContext;
+
+        public RfcServerContext(IRfcServer rfcServer)
+        {
+            _rfcServer = rfcServer;
+        }
+
+        private EitherAsync<RfcErrorInfo, IRfcContext> GetContext()
+        {
+            if (_currentContext == null)
+                _currentContext = new RfcContext(_rfcServer.ClientConnection);
+
+            return Prelude.RightAsync<RfcErrorInfo, IRfcContext>(_currentContext);
+        }
+
+        private Task<Either<RfcErrorInfo, IRfcContext>> GetContextAsync()
+        {
+            return GetContext().ToEither();
+        }
+
+        public void Dispose()
+        {
+            _currentContext?.Dispose();
+            _currentContext = null;
+        }
+
+        public EitherAsync<RfcErrorInfo, IFunction> CreateFunction(string name)
+        {
+            return GetContext().Bind(c => c.CreateFunction(name));
+        }
+
+        public EitherAsync<RfcErrorInfo, IFunction> CreateFunction(string name, CancellationToken cancellationToken)
+        {
+            return GetContext().Bind(c => c.CreateFunction(name, cancellationToken));
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function)
+        {
+            return GetContext().Bind(c => c.InvokeFunction(function));
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> InvokeFunction(IFunction function, CancellationToken cancellationToken)
+        {
+            return GetContext().Bind(c => c.InvokeFunction(function, cancellationToken));
+        }
+
+        public EitherAsync<RfcErrorInfo, IRfcContext> Ping()
+        {
+            return GetContext().Bind(c => c.Ping());
+        }
+
+        public EitherAsync<RfcErrorInfo, IRfcContext> Ping(CancellationToken cancellationToken)
+        {
+            return GetContext().Bind(c => c.Ping(cancellationToken));
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> Commit()
+        {
+            return GetContext().Bind(c => c.Commit());
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> Commit(CancellationToken cancellationToken)
+        {
+            return GetContext().Bind(c => c.Commit(cancellationToken));
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> CommitAndWait()
+        {
+            return GetContext().Bind(c => c.CommitAndWait());
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> CommitAndWait(CancellationToken cancellationToken)
+        {
+            return GetContext().Bind(c => c.CommitAndWait(cancellationToken));
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> Rollback()
+        {
+            return GetContext().Bind(c => c.Rollback());
+        }
+
+        public EitherAsync<RfcErrorInfo, Unit> Rollback(CancellationToken cancellationToken)
+        {
+            return GetContext().Bind(c => c.Rollback(cancellationToken));
+        }
+
+        public Task<Either<RfcErrorInfo, IRfcContext>> PingAsync()
+        {
+            return GetContextAsync().BindAsync(c => c.PingAsync());
+        }
+
+        public Task<Either<RfcErrorInfo, IRfcContext>> PingAsync(CancellationToken cancellationToken)
+        {
+            return GetContextAsync().BindAsync(c => c.PingAsync(cancellationToken));
+        }
+
+        public Task<Either<RfcErrorInfo, Unit>> CommitAsync()
+        {
+            return GetContextAsync().BindAsync(c => c.CommitAsync());
+        }
+
+        public Task<Either<RfcErrorInfo, Unit>> CommitAsync(CancellationToken cancellationToken)
+        {
+            return GetContextAsync().BindAsync(c => c.CommitAsync(cancellationToken));
+        }
+
+        public Task<Either<RfcErrorInfo, Unit>> CommitAndWaitAsync()
+        {
+            return GetContextAsync().BindAsync(c => c.CommitAndWaitAsync());
+        }
+
+        public Task<Either<RfcErrorInfo, Unit>> CommitAndWaitAsync(CancellationToken cancellationToken)
+        {
+            return GetContextAsync().BindAsync(c => c.CommitAndWaitAsync(cancellationToken));
+        }
+
+        public Task<Either<RfcErrorInfo, Unit>> RollbackAsync()
+        {
+            return GetContextAsync().BindAsync(c => c.RollbackAsync());
+        }
+
+        public Task<Either<RfcErrorInfo, Unit>> RollbackAsync(CancellationToken cancellationToken)
+        {
+            return GetContextAsync().BindAsync(c => c.RollbackAsync(cancellationToken));
+        }
+
+        public EitherAsync<RfcErrorInfo, IConnection> GetConnection()
+        {
+            return GetContext().Bind(c => c.GetConnection());
+        }
+    }
+}

--- a/src/YaNco.Core/ServerBuilder.cs
+++ b/src/YaNco.Core/ServerBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using LanguageExt;
 
 namespace Dbosoft.YaNco
@@ -7,14 +8,25 @@ namespace Dbosoft.YaNco
     public class ServerBuilder
     {
         private readonly IDictionary<string, string> _serverParam;
+        [CanBeNull] private IDictionary<string, string> _clientParam;
         private Action<RfcRuntimeConfigurer> _configureRuntime = (c) => { };
+        private Action<RfcServerClientConfigurer> _configureServerClient = (c) => { };
+
         private Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo, IRfcServer>>
             _serverFactory = RfcServer.Create;
+
+        private readonly string _systemId;
+        private Func<EitherAsync<RfcErrorInfo, IConnection>> _connectionFactory;
+
 
         readonly List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)> _functionHandlers = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)>();
 
         public ServerBuilder(IDictionary<string, string> serverParam)
         {
+            if (!serverParam.ContainsKey("SYSID"))
+                throw new ArgumentException("server configuration has to contain parameter SYSID", nameof(serverParam));
+
+            _systemId = serverParam["SYSID"];
             _serverParam = serverParam;
         }
 
@@ -39,6 +51,19 @@ namespace Dbosoft.YaNco
             return this;
         }
 
+        public ServerBuilder WithClientConnection(Func<EitherAsync<RfcErrorInfo, IConnection>> connectionFactory)
+        {
+            _connectionFactory = connectionFactory;
+            return this;
+        }
+
+        public ServerBuilder WithClientConnection(IDictionary<string, string> connectionParams, Action<RfcServerClientConfigurer> configure)
+        {
+            _clientParam = connectionParams;
+            _configureServerClient = configure;
+            return this;
+        }
+
 
         public EitherAsync<RfcErrorInfo, IRfcServer> Build()
         {
@@ -46,8 +71,83 @@ namespace Dbosoft.YaNco
             _configureRuntime(runtimeConfigurer);
             var runtime = runtimeConfigurer.Create();
 
-            return _serverFactory(_serverParam, runtime);
+            //build connection from client build if necessary
+            if (_connectionFactory == null && _clientParam!= null)
+            {
+                var clientBuilder = new ConnectionBuilder(_clientParam);
+                //take runtime of client
+                clientBuilder.ConfigureRuntime(cfg => cfg.UseFactory((l, m, o) => runtime));
 
+                _configureServerClient(new RfcServerClientConfigurer(clientBuilder));
+
+                WithClientConnection(clientBuilder.Build());
+            }
+
+            return _serverFactory(_serverParam, runtime)
+                .Map(s =>
+                {
+                    if (_connectionFactory != null)
+                        s.AddConnectionFactory(_connectionFactory);
+                    return s;
+                })
+                .Bind(RegisterFunctionHandlers);
+
+        }
+
+
+        private EitherAsync<RfcErrorInfo, IRfcServer> RegisterFunctionHandlers(IRfcServer server)
+        {
+            return _functionHandlers.Map(reg =>
+            {
+                var (functionName, configureBuilder, callBackFunction) = reg;
+
+                if (server.RfcRuntime.IsFunctionHandlerRegistered(_systemId, functionName))
+                    return Unit.Default;
+
+                var builder = new FunctionBuilder(server.RfcRuntime, functionName);
+                configureBuilder(builder);
+                return builder.Build().ToAsync().Bind(descr =>
+                {
+                    return server.RfcRuntime.AddFunctionHandler(_systemId,
+                        functionName,
+                        descr,
+                        f => callBackFunction(new CalledFunction(f, () => new RfcServerContext(server)))).ToAsync();
+                });
+
+
+            }).Traverse(l => l).Map(eu => server);
+
+        }
+
+    }
+
+    public class RfcServerClientConfigurer
+    {
+        private readonly ConnectionBuilder _builder;
+
+        public RfcServerClientConfigurer(ConnectionBuilder builder)
+        {
+            _builder = builder;
+            
+        }
+
+        /// <summary>
+        /// This method registers a function handler from a SAP function name. 
+        /// </summary>
+        /// <param name="functionName">Name of function</param>
+        /// <param name="calledFunc">function handler</param>
+        /// <returns>current instance for chaining</returns>
+        /// <remarks>
+        /// The metadata of the function is retrieved from the backend. Therefore the function
+        /// must exists on the SAP backend system.
+        /// Function handlers are registered process wide (in the SAP NW RFC Library).and mapped to backend system id. 
+        /// Multiple registrations of same function and same backend id will therefore have no effect.
+        /// </remarks>
+        public RfcServerClientConfigurer WithFunctionHandler(string functionName,
+            Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
+        {
+            _builder.WithFunctionHandler(functionName, calledFunc);
+            return this;
         }
 
     }

--- a/src/YaNco.Core/ServerBuilder.cs
+++ b/src/YaNco.Core/ServerBuilder.cs
@@ -19,7 +19,7 @@ namespace Dbosoft.YaNco
         private Func<EitherAsync<RfcErrorInfo, IConnection>> _connectionFactory;
 
 
-        readonly List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)> _functionHandlers = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)>();
+        readonly List<(string, Action<IFunctionBuilder>, Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)> _functionHandlers = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>>)>();
 
         public ServerBuilder(IDictionary<string, string> serverParam)
         {
@@ -45,7 +45,7 @@ namespace Dbosoft.YaNco
 
         public ServerBuilder WithFunctionHandler(string functionName,
             Action<IFunctionBuilder> configureBuilder,
-            Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
         {
             _functionHandlers.Add((functionName, configureBuilder, calledFunc));
             return this;
@@ -144,7 +144,7 @@ namespace Dbosoft.YaNco
         /// Multiple registrations of same function and same backend id will therefore have no effect.
         /// </remarks>
         public RfcServerClientConfigurer WithFunctionHandler(string functionName,
-            Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
+            Func<CalledFunction, EitherAsync<RfcErrorInfo, Unit>> calledFunc)
         {
             _builder.WithFunctionHandler(functionName, calledFunc);
             return this;

--- a/src/YaNco.Core/ServerBuilder.cs
+++ b/src/YaNco.Core/ServerBuilder.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using LanguageExt;
+
+namespace Dbosoft.YaNco
+{
+    public class ServerBuilder
+    {
+        private readonly IDictionary<string, string> _serverParam;
+        private Action<RfcRuntimeConfigurer> _configureRuntime = (c) => { };
+        private Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo, IRfcServer>>
+            _serverFactory = RfcServer.Create;
+
+        readonly List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)> _functionHandlers = new List<(string, Action<IFunctionBuilder>, Func<CalledFunction, Either<RfcErrorInfo, Unit>>)>();
+
+        public ServerBuilder(IDictionary<string, string> serverParam)
+        {
+            _serverParam = serverParam;
+        }
+
+        public ServerBuilder ConfigureRuntime(Action<RfcRuntimeConfigurer> configure)
+        {
+            _configureRuntime = configure;
+            return this;
+        }
+
+        public ServerBuilder UseFactory(
+            Func<IDictionary<string, string>, IRfcRuntime, EitherAsync<RfcErrorInfo, IRfcServer>> factory)
+        {
+            _serverFactory = factory;
+            return this;
+        }
+
+        public ServerBuilder WithFunctionHandler(string functionName,
+            Action<IFunctionBuilder> configureBuilder,
+            Func<CalledFunction, Either<RfcErrorInfo, Unit>> calledFunc)
+        {
+            _functionHandlers.Add((functionName, configureBuilder, calledFunc));
+            return this;
+        }
+
+
+        public EitherAsync<RfcErrorInfo, IRfcServer> Build()
+        {
+            var runtimeConfigurer = new RfcRuntimeConfigurer();
+            _configureRuntime(runtimeConfigurer);
+            var runtime = runtimeConfigurer.Create();
+
+            return _serverFactory(_serverParam, runtime);
+
+        }
+
+    }
+}

--- a/src/YaNco.Primitives/RfcErrorException.cs
+++ b/src/YaNco.Primitives/RfcErrorException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Dbosoft.YaNco
+{
+    [Serializable]
+    public class RfcErrorException : Exception
+    {
+        public readonly RfcErrorInfo ErrorInfo;
+
+        public RfcErrorException(RfcErrorInfo errorInfo) : base(errorInfo.Message)
+        {
+            ErrorInfo = errorInfo;
+        }
+        
+
+        public RfcErrorException(RfcErrorInfo errorInfo, Exception inner) : base(errorInfo.Message, inner)
+        {
+            ErrorInfo = errorInfo;
+        }
+
+        protected RfcErrorException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/YaNco.Primitives/RfcErrorInfo.cs
+++ b/src/YaNco.Primitives/RfcErrorInfo.cs
@@ -74,5 +74,10 @@ namespace Dbosoft.YaNco
         {
             return new RfcErrorInfo(RfcRc.RFC_ILLEGAL_STATE, RfcErrorGroup.EXTERNAL_RUNTIME_FAILURE, "unexpected empty result", "", "", "", "", "", "", "", "");
         }
+
+        public RfcErrorInfo Throw()
+        {
+            throw new RfcErrorException(this);
+        }
     }
 }

--- a/test/RfcServerTest/Program.cs
+++ b/test/RfcServerTest/Program.cs
@@ -1,8 +1,10 @@
-﻿
-
+﻿using System.Diagnostics.CodeAnalysis;
 using Dbosoft.YaNco;
 using Microsoft.Extensions.Configuration;
 using RfcServerTest;
+
+[assembly: ExcludeFromCodeCoverage]
+
 
 var configurationBuilder =
     new ConfigurationBuilder();

--- a/test/RfcServerTest/Program.cs
+++ b/test/RfcServerTest/Program.cs
@@ -52,7 +52,7 @@ var serverBuilderWithClientConnection = new ServerBuilder(serverSettings)
             .WithFunctionHandler("ZYANCO_SERVER_FUNCTION_1",
             cf => cf
                 .Input(i => i.GetField<string>("SEND"))
-                .Process(s =>
+                .ProcessAsync(s =>
                 {
                     Console.WriteLine($"Received message from backend: {s}");
                     cancellationTokenSource.Cancel();
@@ -66,8 +66,7 @@ var serverBuilderWithClientConnection = new ServerBuilder(serverSettings)
                                 Output: f => f.MapStructure("ADDRESS", s => s.GetField<string>("FULLNAME")))
                             select userName;
 
-                    }).Match(r => r, l => "John Doe")
-                        .GetAwaiter().GetResult();
+                    }).Match(r => r, l => "John Doe");
 
                 })
                 .Reply((username, f) => f
@@ -108,6 +107,7 @@ var serverBuilderWithoutClientConnection = new ServerBuilder(serverSettings)
             {
                 Console.WriteLine($"Received message from backend: {s}");
                 cancellationTokenSource.Cancel();
+                
             })
             .Reply((_, f) => f
                 .SetField("RECEIVE", "Hello from YaNco")));

--- a/test/RfcServerTest/Program.cs
+++ b/test/RfcServerTest/Program.cs
@@ -1,0 +1,131 @@
+﻿
+
+using Dbosoft.YaNco;
+using Microsoft.Extensions.Configuration;
+using RfcServerTest;
+
+var configurationBuilder =
+    new ConfigurationBuilder();
+
+configurationBuilder.AddInMemoryCollection(new[]
+{
+    new KeyValuePair<string, string>("tests:repeats", "10"),
+    new KeyValuePair<string, string>("tests:rows", "10")
+});
+configurationBuilder.AddEnvironmentVariables("saprfc");
+configurationBuilder.AddCommandLine(args);
+configurationBuilder.AddUserSecrets<Program>();
+
+var config = configurationBuilder.Build();
+
+var serverSettings = new Dictionary<string, string>
+{
+    {"SYSID", "NA1"},
+    {"PROGRAM_ID", "YANCO_TEST"},
+    {"GWHOST",config["saprfc:ashost"]},
+    {"GWSERV", "sapgw" + config["saprfc:sysnr"]},
+    {"REG_COUNT", "2"},
+    {"TRACE", "1"}
+
+};
+
+var clientSettings = new Dictionary<string, string>
+{
+    {"ashost", config["saprfc:ashost"]},
+    {"sysnr", config["saprfc:sysnr"]},
+    {"client", config["saprfc:client"]},
+    {"user", config["saprfc:username"]},
+    {"passwd", config["saprfc:password"]},
+    {"lang", "EN"},
+};
+
+
+var cancellationTokenSource = new CancellationTokenSource();
+
+
+var serverBuilderWithClientConnection = new ServerBuilder(serverSettings)
+    .ConfigureRuntime(c =>
+        c.WithLogger(new SimpleConsoleLogger()))
+
+    .WithClientConnection(clientSettings, 
+        c => c
+            .WithFunctionHandler("ZYANCO_SERVER_FUNCTION_1",
+            cf => cf
+                .Input(i => i.GetField<string>("SEND"))
+                .Process(s =>
+                {
+                    Console.WriteLine($"Received message from backend: {s}");
+                    cancellationTokenSource.Cancel();
+
+                    return cf.UseRfcContext(context =>
+                    {
+                        return from connection in context.GetConnection()
+                            from attributes in connection.GetAttributes()
+                            from userName in context.CallFunction("BAPI_USER_GET_DETAIL",
+                                Input: f => f.SetField("USERNAME", attributes.User),
+                                Output: f => f.MapStructure("ADDRESS", s => s.GetField<string>("FULLNAME")))
+                            select userName;
+
+                    }).Match(r => r, l => "John Doe")
+                        .GetAwaiter().GetResult();
+
+                })
+                .Reply((username, f) => f
+                    .SetField("RECEIVE", $"Hello {username}!")))
+        );
+
+
+var rfcServer = await serverBuilderWithClientConnection.Build()
+    .StartOrException();
+
+Console.WriteLine("Server with client connection is ready");
+Console.WriteLine("call function ZYANCO_SERVER_FUNCTION_1 from backend");
+
+try
+{
+    await Task.Delay(Timeout.Infinite, cancellationTokenSource.Token);
+}
+catch(TaskCanceledException){}
+
+
+await rfcServer.Stop().ToEither();
+
+Console.WriteLine("Server stopped");
+
+
+cancellationTokenSource = new CancellationTokenSource();
+
+var serverBuilderWithoutClientConnection = new ServerBuilder(serverSettings)
+    .WithFunctionHandler(
+        "ZYANCO_SERVER_FUNCTION_2",
+        b => b
+            .AddChar("SEND", RfcDirection.Import, 30)
+            .AddChar("RECEIVE", RfcDirection.Export, 30),
+        cf => cf
+            .Input(i =>
+                i.GetField<string>("SEND"))
+            .Process(s =>
+            {
+                Console.WriteLine($"Received message from backend: {s}");
+                cancellationTokenSource.Cancel();
+            })
+            .Reply((_, f) => f
+                .SetField("RECEIVE", "Hello from YaNco")));
+
+rfcServer = await serverBuilderWithoutClientConnection.Build()
+    .StartOrException();
+
+Console.WriteLine("Server without client connection is ready");
+Console.WriteLine("call function ZYANCO_SERVER_FUNCTION_2 from backend");
+Console.WriteLine("Server ready");
+
+try
+{
+    await Task.Delay(Timeout.Infinite, cancellationTokenSource.Token);
+}
+catch (TaskCanceledException) { }
+
+
+await rfcServer.Stop().ToEither();
+
+Console.WriteLine("Server stopped");

--- a/test/RfcServerTest/RfcServerTest.csproj
+++ b/test/RfcServerTest/RfcServerTest.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <UserSecretsId>6285DE94-384A-4301-9E06-CCC6A16C6986</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CompareNETObjects" Version="4.78.0" />
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\YaNco.Core\YaNco.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/RfcServerTest/SimpleConsoleLogger.cs
+++ b/test/RfcServerTest/SimpleConsoleLogger.cs
@@ -1,0 +1,98 @@
+﻿using System.Text;
+using Dbosoft.YaNco;
+using Newtonsoft.Json;
+
+namespace RfcServerTest
+{
+    public class SimpleConsoleLogger : ILogger
+    {
+        public void LogException(Exception exception, string message)
+        {
+            Console.WriteLine($"{message} - Exception: {exception}");
+        }
+
+        public void LogException(Exception exception)
+        {
+            LogException(exception, "");
+        }
+
+        public void LogTrace(string message, object data)
+        {
+           //Console.WriteLine($"TRACE\t{message}{ObjectToString(data)}");
+        }
+
+        public void LogError(string message, object data)
+        {
+            Console.WriteLine($"ERROR\t{message}{ObjectToString(data)}");
+        }
+
+        public void LogDebug(string message, object data)
+        {
+            if (data is RfcErrorInfo { Key: "RFC_TABLE_MOVE_EOF" })
+                return;
+
+            Console.WriteLine($"DEBUG\t{message}{ObjectToString(data)}");
+        }
+
+        public void LogTrace(string message)
+        {
+            LogTrace(message, null);
+        }
+
+        public void LogDebug(string message)
+        {
+            LogDebug(message, null);
+        }
+
+        public void LogError(string message)
+        {
+            LogError(message, null);
+        }
+
+        public static string ObjectToString(object valueObject)
+        {
+            var dataString = new StringBuilder();
+            if (valueObject == null)
+                return "";
+
+            dataString.Append(", Data: ");
+
+            dataString.Append(JsonConvert.SerializeObject(valueObject, new JsonSerializerSettings
+            {
+                Converters = new List<JsonConverter>(new[]{new HandleToStringJsonConverter() })
+            }));
+
+            return dataString.ToString();
+
+        }
+
+        class HandleToStringJsonConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                if(objectType.BaseType  != null 
+                   && objectType.BaseType.FullName != null 
+                   && (objectType.BaseType.FullName.StartsWith("Dbosoft.SAP.NWRfc.Native.HandleBase") 
+                   || objectType.BaseType.FullName.StartsWith("Dbosoft.SAP.NWRfc.Native.DataContainerBase")))
+                    return true;
+                return false;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                var typeName = value.GetType().Name;                
+                writer.WriteValue($"{typeName}<{value}>");
+            }
+
+            public override bool CanRead
+            {
+                get { return false; }
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -44,8 +43,7 @@ namespace SAPSystemTests
                 {"client", config["saprfc:client"]},
                 {"user", config["saprfc:username"]},
                 {"passwd", config["saprfc:password"]},
-                {"lang", "EN"}
-
+                {"lang", "EN"},
             };
 
             var rows = Convert.ToInt32(config["tests:rows"]);
@@ -74,10 +72,7 @@ namespace SAPSystemTests
                 .ConfigureRuntime(c =>
                     c.WithLogger(new SimpleConsoleLogger()));
 
-
-            var rfcServer = await RfcServer.Create(settings, new RfcRuntime())
-                .Bind(s => s.Start()).ToEither();
-
+            
             var connectionFunc = connectionBuilder.Build();
 
             using (var context = new RfcContext(connectionFunc))

--- a/test/YaNco.Core.Tests/ConnectionTests.cs
+++ b/test/YaNco.Core.Tests/ConnectionTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 using Dbosoft.YaNco;
 using LanguageExt;
@@ -8,6 +10,9 @@ using YaNco.Core.Tests.RfcMock;
 
 namespace YaNco.Core.Tests
 {
+    
+    [ExcludeFromCodeCoverage]
+
     public class ConnectionTests
     {
         [Fact]

--- a/test/YaNco.Core.Tests/DeepAssert.cs
+++ b/test/YaNco.Core.Tests/DeepAssert.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using KellermanSoftware.CompareNetObjects;
 
 namespace YaNco.Core.Tests
 {
+    [ExcludeFromCodeCoverage]
     public static class DeepAssert {
 
         public static void Equal<T> (T expected, T actual, params string[] propertiesToIgnore) {

--- a/test/YaNco.Core.Tests/ObjectEqualException.cs
+++ b/test/YaNco.Core.Tests/ObjectEqualException.cs
@@ -1,7 +1,9 @@
-﻿using Xunit.Sdk;
+﻿using System.Diagnostics.CodeAnalysis;
+using Xunit.Sdk;
 
 namespace YaNco.Core.Tests
 {
+    [ExcludeFromCodeCoverage]
     public class ObjectEqualException : AssertActualExpectedException
     {
         private readonly string message;

--- a/test/YaNco.Core.Tests/RfcContextTests.cs
+++ b/test/YaNco.Core.Tests/RfcContextTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using Dbosoft.YaNco;
+using LanguageExt;
+using Moq;
+using Xunit;
+using YaNco.Core.Tests.RfcMock;
+
+namespace YaNco.Core.Tests
+{
+    public class RfcContextTests
+    {
+
+        [Fact]
+        public async Task Connection_Is_Created()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>()
+                .SetupOpenConnection(out _);
+
+            using (var rfcContext = new RfcContext(
+                       rfcRuntimeMock.CreateConnectionFactory()))
+            {
+                await rfcContext.GetConnection().IfLeft(l => l.Throw());
+
+            }
+
+            rfcRuntimeMock.VerifyAll();
+
+
+        }
+
+        [Fact]
+        public async Task Function_Is_Called()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>()
+                .SetupOpenConnection(out var connHandle);
+
+            rfcRuntimeMock.SetupFunction("A_FUNC", connHandle,
+                (r, h) =>
+                {
+                    r.Setup(x => x.GetFieldValue<string>(h, It.IsAny<Func<Either<RfcErrorInfo, RfcFieldInfo>>>()
+                        ))
+                        .Returns("VALUE");
+                });
+
+            using (var rfcContext = new RfcContext(rfcRuntimeMock.CreateConnectionFactory()))
+            {
+                await rfcContext.CallFunction("A_FUNC",
+                        f => f.GetField<string>("FIELD"),
+                        f => f)
+                    .IfLeft(l => { l.Throw(); });
+
+            }
+
+            rfcRuntimeMock.VerifyAll();
+
+
+        }
+
+        [Fact]
+        public async Task Ping_Is_Called()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>()
+                .SetupOpenConnection(out var connHandle);
+
+            rfcRuntimeMock.SetupFunction("RFC_PING", connHandle,
+                (r, h) => { });
+
+            using (var rfcContext = new RfcContext(rfcRuntimeMock.CreateConnectionFactory()))
+            {
+                await rfcContext.Ping()
+                    .IfLeft(l => { l.Throw(); });
+
+                rfcRuntimeMock.VerifyAll();
+
+
+                (await rfcContext.PingAsync())
+                    .IfLeft(l => { l.Throw(); });
+
+            }
+
+
+        }
+    }
+}

--- a/test/YaNco.Core.Tests/RfcMock/RfcContextMockExtensions.cs
+++ b/test/YaNco.Core.Tests/RfcMock/RfcContextMockExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Dbosoft.YaNco;
 using LanguageExt;
@@ -8,6 +9,7 @@ using Moq.Language.Flow;
 
 namespace YaNco.Core.Tests.RfcMock
 {
+    [ExcludeFromCodeCoverage]
     public static class RfcContextMockExtensions
     {
         public static Mock<IRfcContext> SetupFunction(this Mock<IRfcContext> self, string functionName, Action<Mock<IFunction>> functionBuilder)

--- a/test/YaNco.Core.Tests/RfcMock/TableMockBuilder.cs
+++ b/test/YaNco.Core.Tests/RfcMock/TableMockBuilder.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Dbosoft.YaNco;
 using LanguageExt;
 using Moq;
 
 namespace YaNco.Core.Tests.RfcMock
 {
+    [ExcludeFromCodeCoverage]
     public class TableMockBuilder
     {
         public List<Mock<IStructure>> Structures { get; private set; } = new List<Mock<IStructure>>();

--- a/test/YaNco.Core.Tests/RfcServerTests.cs
+++ b/test/YaNco.Core.Tests/RfcServerTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dbosoft.YaNco;
+using LanguageExt;
+using Moq;
+using Xunit;
+using YaNco.Core.Tests.RfcMock;
+
+namespace YaNco.Core.Tests
+{
+    public class RfcServerTests
+    {
+        [Fact]
+        public async Task Server_Is_Created()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>();
+            rfcRuntimeMock.SetupCreateServer(out _);
+
+            await rfcRuntimeMock.CreateServer();
+
+            rfcRuntimeMock.VerifyAll();
+
+        }
+
+        [Fact]
+        public async Task Server_Is_Started()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>();
+            rfcRuntimeMock.SetupCreateServer(out var handle);
+            rfcRuntimeMock.Setup(x =>
+                    x.LaunchServer(handle.Object))
+                .Returns(Unit.Default);
+
+
+            var rfcServer = await rfcRuntimeMock.CreateServer();
+            await rfcServer.Start()
+                .IfLeft(l => throw new Exception(l.Message));
+
+            rfcRuntimeMock.VerifyAll();
+
+        }
+
+        [Fact]
+        public async Task Server_Is_Stopped()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>();
+            rfcRuntimeMock.SetupCreateServer(out var handle);
+            rfcRuntimeMock.Setup(x =>
+                    x.ShutdownServer(handle.Object, 0))
+                .Returns(Unit.Default);
+
+
+            var rfcServer = await rfcRuntimeMock.CreateServer();
+            await rfcServer.Stop()
+                .IfLeft(l => throw new Exception(l.Message));
+
+            rfcRuntimeMock.VerifyAll();
+
+        }
+
+        [Fact]
+        public async Task ConnectionPlaceHolder_Does_Nothing()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>();
+            rfcRuntimeMock.SetupCreateServer(out var handle);
+            var rfcServer = await rfcRuntimeMock.CreateServer();
+
+            var conn =
+                (await rfcServer.ClientConnection().ToEither())
+                .RightAsEnumerable().FirstOrDefault();
+
+            Assert.Same(rfcRuntimeMock.Object, conn.RfcRuntime);
+            Assert.False(conn.Disposed);
+            Assert.True((await conn.GetAttributes().ToEither()).IsLeft);
+            Assert.True((await conn.CreateFunction("").ToEither()).IsLeft);
+            Assert.True((await conn.Cancel().ToEither()).IsLeft);
+            Assert.True((await conn.Commit().ToEither()).IsLeft);
+            Assert.True((await conn.CommitAndWait().ToEither()).IsLeft);
+            Assert.True((await conn.Rollback().ToEither()).IsLeft);
+            Assert.True((await conn.InvokeFunction(
+                new Mock<IFunction>().Object).ToEither()).IsLeft);
+
+            Assert.True((await conn.Commit(CancellationToken.None).ToEither()).IsLeft);
+            Assert.True((await conn.CommitAndWait(CancellationToken.None).ToEither()).IsLeft);
+            Assert.True((await conn.Rollback(CancellationToken.None).ToEither()).IsLeft);
+            Assert.True((await conn.InvokeFunction(
+                new Mock<IFunction>().Object, CancellationToken.None).ToEither()).IsLeft);
+            Assert.True(
+#pragma warning disable CS0618
+                (await conn.AllowStartOfPrograms(_ => RfcErrorInfo.Ok()).ToEither()).IsLeft);
+#pragma warning restore CS0618
+
+            conn.Dispose();
+            Assert.True(conn.Disposed);
+
+
+        }
+
+        [Fact]
+        public async Task Server_Is_Invalid_After_Disposal()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>();
+            rfcRuntimeMock.SetupCreateServer(out var handle);
+
+            rfcRuntimeMock.Setup(x =>
+                    x.LaunchServer(handle.Object))
+                .Returns(Unit.Default);
+
+            var rfcServer = await rfcRuntimeMock.CreateServer();
+            rfcServer.Dispose();
+            rfcServer.Start();
+
+            rfcRuntimeMock
+                .Verify(x=>x.LaunchServer(handle.Object), Times.Never());
+
+
+        }
+
+        [Fact]
+        public async Task Server_Never_Throws()
+        {
+            var rfcRuntimeMock = new Mock<IRfcRuntime>();
+            rfcRuntimeMock.SetupCreateServer(out var handle);
+
+            rfcRuntimeMock.Setup(x =>
+                    x.LaunchServer(handle.Object))
+                .Throws<Exception>();
+
+            var rfcServer = await rfcRuntimeMock.CreateServer();
+
+            rfcServer.Start();
+
+
+        }
+    }
+}


### PR DESCRIPTION
This PR solves #147 by implementing a RFC Server in YaNco. 

RfRF Servers are build from ServerBuilder class using same concepts as the ConnectionBuilder for clients. 
RFC Servers have to register functions handlers to retrieve requests from the ABAP backend. Concept is same as function builder for client callbacks. 
RFC Servers can be created without metadata connections to backend just from known metadata. 
