### PR TITLE
Don't throw InvalidOperationException

### DIFF
--- a/src/YaNco.Core/Connection.cs
+++ b/src/YaNco.Core/Connection.cs
@@ -85,9 +85,13 @@ namespace Dbosoft.YaNco
                     catch (Exception ex)
                     {
                         rfcRuntime.Logger.IfSome(l => l.LogException(ex));
+                        return (null, Prelude.Left(RfcErrorInfo.Error(ex.Message)));
                     }
 
-                    throw new InvalidOperationException();
+                    rfcRuntime.Logger.IfSome(l => l.LogError(
+                        $"Invalid rfc connection message {msg.GetType()}"));
+                    return (null, Prelude.Left(RfcErrorInfo.Error($"Invalid rfc connection message {msg.GetType().Name}")));
+
                 });
         }
 

--- a/src/YaNco.Core/RfcServer.cs
+++ b/src/YaNco.Core/RfcServer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using Dbosoft.Functional;
 using LanguageExt;
@@ -75,9 +74,13 @@ namespace Dbosoft.YaNco
                     catch (Exception ex)
                     {
                         rfcRuntime.Logger.IfSome(l => l.LogException(ex));
+                        return (null, Prelude.Left(RfcErrorInfo.Error(ex.Message)));
                     }
 
-                    throw new InvalidOperationException();
+                    rfcRuntime.Logger.IfSome(l => l.LogError(
+                        $"Invalid rfc server message {msg.GetType()}"));
+                    return (null, Prelude.Left(RfcErrorInfo.Error($"Invalid rfc server message {msg.GetType().Name}")));
+
                 });
 
         }


### PR DESCRIPTION
If a exception occurs in RFCServer or Connection actor message a InvalidOperationException exception is thrown. Instead we have to return a Either in left state. 