### PR TITLE
Create runtime only once per ConnectionBuilder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,19 @@ steps:
   inputs:
     packageType: 'sdk'
     version: '3.x'
+    performMultiLevelLookup: true
+
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '5.x'
+    performMultiLevelLookup: true   
+
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '6.x'
+    performMultiLevelLookup: true   
     
 - task: DotNetCoreCLI@2
   displayName: dotnet restore

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '3.1'
+    version: '3.x'
     
 - task: DotNetCoreCLI@2
   displayName: dotnet restore

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,11 @@ steps:
   inputs:
     versionSpec: '5.x'
 
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '3.1'
+    
 - task: DotNetCoreCLI@2
   displayName: dotnet restore
   inputs:

--- a/test/YaNco.Core.Tests/CreateRuntimeTests.cs
+++ b/test/YaNco.Core.Tests/CreateRuntimeTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dbosoft.YaNco;
+using LanguageExt;
+using Moq;
+using Xunit;
+
+namespace YaNco.Core.Tests
+{
+    public class CreateRuntimeTests
+    {
+
+        [Fact]
+        public void Runtime_Can_Be_Initialized_in_Parallel()
+        {
+            var connectionBuilder = new ConnectionBuilder(new Dictionary<string, string>());
+            var connectionMock = new Mock<IConnection>();
+            var emptyAttributes = new ConnectionAttributes("", "", "", "", "", "", "", "", "", "",
+                    "", "", "", "", "", "", "", "", "", "", "", "", "", "");
+
+            connectionMock.Setup(x => x.GetAttributes()).Returns(Prelude.RightAsync<RfcErrorInfo, ConnectionAttributes>(emptyAttributes));
+
+            connectionBuilder.UseFactory((_, r) => Prelude.RightAsync<RfcErrorInfo, IConnection>(connectionMock.Object));
+            var buildFunc = connectionBuilder.Build();
+
+            var options = new ParallelOptions { MaxDegreeOfParallelism = int.MaxValue };
+            Parallel.ForEach(Enumerable.Range(0, 1000), options, _ =>
+            {
+                buildFunc().Match(Assert.NotNull, l => l.Throw()).GetAwaiter().GetResult();
+
+            });
+        }
+    }
+}


### PR DESCRIPTION
Changed ConnectionBuilder to create IRfcRuntime only one time and not in parallel. Should solve #235. 