### PR TITLE
Make `TableHandle` implement `IDataContainerHandle` (fixes #260)

### DIFF
--- a/src/YaNco.Core/Internal/TableHandle.cs
+++ b/src/YaNco.Core/Internal/TableHandle.cs
@@ -2,7 +2,7 @@
 
 namespace Dbosoft.YaNco.Internal
 {
-    public class TableHandle : ITableHandle
+    public class TableHandle : ITableHandle, IDataContainerHandle
     {
         private readonly bool _destroyable;
 
@@ -12,7 +12,7 @@ namespace Dbosoft.YaNco.Internal
             Ptr = ptr;
         }
 
-        internal IntPtr Ptr { get; private set; }
+        public IntPtr Ptr { get; private set; }
 
         public void Dispose()
         {


### PR DESCRIPTION
This fixes `NullReferenceException` when calling `Dbosoft.YaNco.Table.GetTypeDescription()` method.