### PR TITLE
added GetTypeDescription overload for ITableHandle

### DIFF
--- a/src/YaNco.Abstractions/IRfcRuntime.cs
+++ b/src/YaNco.Abstractions/IRfcRuntime.cs
@@ -25,6 +25,7 @@ namespace Dbosoft.YaNco
 
         Either<RfcErrorInfo, IFunctionDescriptionHandle> GetFunctionDescription(IFunctionHandle functionHandle);
         Either<RfcErrorInfo, ITypeDescriptionHandle> GetTypeDescription(IDataContainerHandle dataContainer);
+        Either<RfcErrorInfo, ITypeDescriptionHandle> GetTypeDescription(ITableHandle tableHandle);
         Either<RfcErrorInfo, ITypeDescriptionHandle> GetTypeDescription(IConnectionHandle connectionHandle, string typeName);
         Either<RfcErrorInfo, string> GetFunctionName(IFunctionDescriptionHandle descriptionHandle);
         Either<RfcErrorInfo, int> GetTypeFieldCount(ITypeDescriptionHandle descriptionHandle);

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -81,6 +81,14 @@ namespace Dbosoft.YaNco.Internal
 
         }
 
+        public static TypeDescriptionHandle GetTypeDescription(TableHandle tableHandle,
+            out RfcErrorInfo errorInfo)
+        {
+            var ptr = Interopt.RfcDescribeType(tableHandle.Ptr, out errorInfo);
+            return ptr == IntPtr.Zero ? null : new TypeDescriptionHandle(ptr);
+
+        }
+
         [CanBeNull]
         public static TypeDescriptionHandle GetTypeDescription(ConnectionHandle connectionHandle, string typeName,
             out RfcErrorInfo errorInfo)

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -169,6 +169,14 @@ namespace Dbosoft.YaNco
 
         }
 
+        public Either<RfcErrorInfo, ITypeDescriptionHandle> GetTypeDescription(ITableHandle table)
+        {
+            Logger.IfSome(l => l.LogTrace("reading type description by table handle", table));
+            ITypeDescriptionHandle handle = Api.GetTypeDescription(table as TableHandle, out var errorInfo);
+            return ResultOrError(handle, errorInfo);
+
+        }
+
         public Either<RfcErrorInfo, ITypeDescriptionHandle> GetTypeDescription(IConnectionHandle connectionHandle, string typeName)
         {
             Logger.IfSome(l => l.LogTrace("reading type description by type name", typeName));


### PR DESCRIPTION
It is currently not possible to read the type description of a table type using the IRfcRuntime API. The current implementation is limited to data containers (Structures and Functions).

This PR adds GetTypeDescription to IRFcRuntime and to API that expects a ITableHandle (Internal.TableHandle for the API variant). 

fixes #260 