### PR TITLE
added helper method for IRfcContext to access SAPRfcRuntime

### DIFF
--- a/src/YaNco.Abstractions/Deprecations.cs
+++ b/src/YaNco.Abstractions/Deprecations.cs
@@ -5,7 +5,11 @@ public static class Deprecations
     public const string RfcRuntime =
         """
         RfcRuntime is deprecated and has been replaced by IO effects provided via SAPRfcRuntime.
-        To access the IO effects you can use the Prelude.runtime<RT>() method, where RT is the type of the runtime you are using.
+        If you are using a RfcContext you should consider migrating to RfcContext<RT>. 
+        Then can use the Prelude.runtime<RT>() method, where RT is the type of the runtime you are using.
         Common used methods are also accessible via the SAPRfc<RT> class.
+        
+        If you don't want to migrate to RfcContext<RT> you can also use the extension method 
+        GetSAPRfcRuntime() that accesses the runtime of the connection within the context.       
         """;
 }

--- a/src/YaNco.Abstractions/IConnection.cs
+++ b/src/YaNco.Abstractions/IConnection.cs
@@ -117,6 +117,6 @@ namespace Dbosoft.YaNco
         [Obsolete(Deprecations.RfcRuntime)]
         IRfcRuntime RfcRuntime { get;  }
 
-        T GetRuntimeSettings<T>() where T : SAPRfcRuntimeSettings;
+        HasEnvRuntimeSettings ConnectionRuntime { get; }
     }
 }

--- a/src/YaNco.Abstractions/IRfcContext.cs
+++ b/src/YaNco.Abstractions/IRfcContext.cs
@@ -223,5 +223,6 @@ namespace Dbosoft.YaNco
         /// <returns>A <see cref="EitherAsync{RfcError,IConnection}"/> with any rfc error as left state and <seealso cref="IConnection"/> as right state.</returns>
         EitherAsync<RfcError, IConnection> GetConnection();
 
+
     }
 }

--- a/src/YaNco.Core/Connection.cs
+++ b/src/YaNco.Core/Connection.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dbosoft.Functional;
 using Dbosoft.YaNco.Live;
+using Dbosoft.YaNco.Test;
 using LanguageExt;
 
 namespace Dbosoft.YaNco
@@ -26,10 +27,7 @@ namespace Dbosoft.YaNco
         public IRfcRuntime RfcRuntime => new RfcRuntime(SAPRfcRuntime.New(
             _runtime.Env.Source, _runtime.Env.Settings));
 
-        public T GetRuntimeSettings<T>() where T : SAPRfcRuntimeSettings
-        {
-            return _runtime.Env.Settings as T;
-        }
+        public HasEnvRuntimeSettings ConnectionRuntime => _runtime;
 
         public Connection(
             RT runtime,
@@ -288,5 +286,4 @@ namespace Dbosoft.YaNco
             }
         }
     }
-
 }

--- a/src/YaNco.Core/ConnectionPlaceholder.cs
+++ b/src/YaNco.Core/ConnectionPlaceholder.cs
@@ -91,6 +91,7 @@ internal class ConnectionPlaceholder : IConnection
     public bool Disposed { get; private set; }
 #pragma warning disable CS0618 // Type or member is obsolete
     public IRfcRuntime RfcRuntime { get; } = new RfcRuntime(SAPRfcRuntime.Default);
+    public HasEnvRuntimeSettings ConnectionRuntime { get; } = SAPRfcRuntime.Default;
 #pragma warning restore CS0618 // Type or member is obsolete
     public T GetRuntimeSettings<T>() where T : SAPRfcRuntimeSettings
     {

--- a/src/YaNco.Core/RfcContextRuntimeAccess.cs
+++ b/src/YaNco.Core/RfcContextRuntimeAccess.cs
@@ -1,0 +1,20 @@
+﻿using Dbosoft.YaNco.Live;
+using LanguageExt;
+
+namespace Dbosoft.YaNco;
+
+public static class RfcContextRuntimeAccess
+{
+    /// <summary>
+    /// This method is a helper method to get the <see cref="SAPRfcRuntime"/> from a <see cref="IRfcContext"/>.
+    /// If you have to use this method please consider migrating to <see cref="IRfcContext{RT}"/>
+    /// where you can access the runtime directly via the <see cref="Prelude.runtime{RT}"/> method.
+    /// </summary>
+    /// <param name="context">context to be used</param>
+    /// <returns><see cref="SAPRfcRuntime"/> that can be used to t run IO effects within the <see cref="IRfcContext{RT}"/></returns>
+    public static EitherAsync<RfcError, SAPRfcRuntime> GetSAPRfcRuntime(this IRfcContext context)
+    {
+        // the runtime if RfcContext is always a SAPRfcRuntime
+        return context.GetConnection().Map(c => (SAPRfcRuntime) c.ConnectionRuntime);
+    }
+}

--- a/test/YaNco.Core.Tests/RfcContextTests.cs
+++ b/test/YaNco.Core.Tests/RfcContextTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dbosoft.YaNco;
+using Dbosoft.YaNco.Live;
+using Dbosoft.YaNco.TypeMapping;
 using LanguageExt;
 using Moq;
 using Xunit;
@@ -75,6 +77,34 @@ namespace YaNco.Core.Tests
             functionIO.VerifyAll();
 
 
+        }
+
+
+        [Fact]
+        public async Task Can_access_buildIn_SAPRfcRuntime()
+        {
+            var connectionIO = new Mock<SAPRfcConnectionIO>();
+            connectionIO.SetupOpenConnection(out _);
+            var fieldMapper = new Mock<IFieldMapper>();
+            var connFunc = new ConnectionBuilder(new Dictionary<string, string>())
+                .ConfigureRuntime(c => c.UseSettingsFactory((l, m, o) =>
+                    new SAPRfcRuntimeSettings(l, fieldMapper.Object, o)
+                    {
+                        RfcConnectionIO = connectionIO.Object,
+                        RfcFunctionIO = new Mock<SAPRfcFunctionIO>().Object
+                    })).Build();
+
+
+            using (var rfcContext = new RfcContext(connFunc))
+            {
+                await rfcContext.GetConnection().IfLeft(l => l.Throw());
+
+                var runtime = await rfcContext.GetSAPRfcRuntime()
+                    .IfLeft(default(SAPRfcRuntime));
+                Assert.Equal(fieldMapper.Object,runtime.Env.Settings.FieldMapper);
+            }
+
+            connectionIO.VerifyAll();
         }
     }
 }


### PR DESCRIPTION
As IRfcRuntime is deprecated but IRfcContext is not, we have to provide a way that users can still access all IO effects from a RfcContext. As it is required to run all IO effects with a runtime they need access to it. 

The added extension method GetSAPRfcRuntime allows to access the build in SAPRfcRuntime of the RfcContext via casting the connection field ConnectionRuntime to SAPRfcRuntime.