### PR TITLE
Bug fix: CachingConverterResolver concurrency

### DIFF
--- a/src/YaNco.Core/TypeMapping/CachingConverterResolver.cs
+++ b/src/YaNco.Core/TypeMapping/CachingConverterResolver.cs
@@ -20,20 +20,25 @@ namespace Dbosoft.YaNco.TypeMapping
         public IEnumerable<IToAbapValueConverter<T>> GetToRfcConverters<T>(RfcType rfcType)
         {
             var sourceType = typeof(T);
-            var key = $"{rfcType}_{sourceType}";
+            var key = $"{rfcType}_{sourceType.AssemblyQualifiedName}";
 
-            if (!_toRfcConverters.ContainsKey(key))
+            if (!_toRfcConverters.TryGetValue(key, out var entry))
             {
                 var converters = _decoratedResolver.GetToRfcConverters<T>(rfcType).ToArray();
-                _toRfcConverters.Add(key, converters.Length == 0 ? null : converters);
-
+                entry = converters.Length == 0 ? null : converters;
+                try
+                {
+                    _toRfcConverters.Add(key, entry);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
             }
-
-            var entry = _toRfcConverters[key];
 
             if (entry != null)
                 return (IEnumerable<IToAbapValueConverter<T>>)entry;
-            return new IToAbapValueConverter<T>[0];
+            return Array.Empty<IToAbapValueConverter<T>>();
 
 
         }
@@ -41,19 +46,26 @@ namespace Dbosoft.YaNco.TypeMapping
         public IEnumerable<IFromAbapValueConverter<T>> GetFromRfcConverters<T>(RfcType rfcType, Type abapValueType)
         {
             var targetType = typeof(T);
-            var key = $"{rfcType}_{targetType}";
+            var key = $"{rfcType}_{targetType.AssemblyQualifiedName}";
 
-            if (!_fromRfcConverters.ContainsKey(key))
+            if (!_fromRfcConverters.TryGetValue(key, out var entry))
             {
                 var converters = _decoratedResolver.GetFromRfcConverters<T>(rfcType, abapValueType).ToArray();
-                _fromRfcConverters.Add(key, converters.Length == 0 ? null : converters);
+                entry = converters.Length == 0 ? null : converters;
+                try
+                {
+                    _fromRfcConverters.Add(key, entry);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
             }
-
-            var entry = _fromRfcConverters[key];
 
             if (entry != null)
                 return (IEnumerable<IFromAbapValueConverter<T>>)entry;
-            return new IFromAbapValueConverter<T>[0];
+            return Array.Empty<IFromAbapValueConverter<T>>();
         }
+
     }
 }


### PR DESCRIPTION
The CachingConverterResolver sometimes throws on concurrent request. Code was updated to improve stability and to return a result even if cache update failed.

Cache was also updated to cache .NET type with full qualified assembly name.