### PR TITLE
Added IO for global library functions

### DIFF
--- a/YaNco.sln.DotSettings
+++ b/YaNco.sln.DotSettings
@@ -7,6 +7,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BAPI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BAPIRET/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cpic/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dbosoft/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IDOC/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Interopt/@EntryIndexedValue">True</s:Boolean>

--- a/src/YaNco.Abstractions/SAPRfcRuntimeSettings.cs
+++ b/src/YaNco.Abstractions/SAPRfcRuntimeSettings.cs
@@ -53,4 +53,5 @@ public class SAPRfcRuntimeSettings
     public SAPRfcFunctionIO RfcFunctionIO { get; set; }
     public SAPRfcConnectionIO RfcConnectionIO { get; set; }
     public SAPRfcServerIO RfcServerIO { get; set; }
+    public SAPRfcLibraryIO RfcLibraryIO { get; set; }
 }

--- a/src/YaNco.Abstractions/Traits/HasSAPRfcLibrary.cs
+++ b/src/YaNco.Abstractions/Traits/HasSAPRfcLibrary.cs
@@ -1,0 +1,13 @@
+﻿using JetBrains.Annotations;
+using LanguageExt;
+
+namespace Dbosoft.YaNco.Traits;
+
+[PublicAPI]
+// ReSharper disable once InconsistentNaming
+public interface HasSAPRfcLibrary<RT> : IHasEnvRuntimeSettings
+    where RT : struct
+{
+    Eff<RT, SAPRfcLibraryIO> RfcLibraryEff { get; }
+
+}

--- a/src/YaNco.Abstractions/Traits/SAPRfcLibraryIO.cs
+++ b/src/YaNco.Abstractions/Traits/SAPRfcLibraryIO.cs
@@ -1,0 +1,17 @@
+﻿using LanguageExt;
+
+namespace Dbosoft.YaNco.Traits;
+
+// ReSharper disable once InconsistentNaming
+public interface SAPRfcLibraryIO
+{
+    Either<RfcError, System.Version> GetVersion();
+    Either<RfcError, Unit> SetTraceDirectory(string traceDirectory);
+    Either<RfcError, Unit> SetMaximumTraceFiles(int traceFiles);
+    Either<RfcError, Unit> SetCpicTraceLevel(int traceLevel);
+
+    Either<RfcError, Unit> LoadCryptoLibrary(string libraryPath);
+    Either<RfcError, Unit> SetIniDirectory(string iniDirectory);
+    Either<RfcError, Unit> ReloadRfcIni();
+
+}

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -9,7 +9,41 @@ namespace Dbosoft.YaNco.Internal;
 [ExcludeFromCodeCoverage]
 public static class Api
 {
-        
+    public static Version GetVersion()
+    {
+        _ = Interopt.RfcGetVersion(out var major, out var minor, out var patch);
+        return new Version((int) major, (int) minor, (int) patch);
+    }
+
+    public static RfcRc SetTraceDirectory(string traceDirectory, out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcSetTraceDir(traceDirectory, out errorInfo);
+    }
+    public static RfcRc SetMaximumTraceFiles(int maxTraceFiles, out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcSetMaximumStoredTraceFiles(maxTraceFiles, out errorInfo);
+    }
+
+    public static RfcRc SetCpicTraceLevel(int traceLevel, out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcSetCpicTraceLevel((uint) traceLevel, out errorInfo);
+    }
+
+    public static RfcRc SetIniDirectory(string iniDirectory, out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcSetIniPath(iniDirectory, out errorInfo);
+    }
+
+    public static RfcRc ReloadIniFile(out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcReloadIniFile(out errorInfo);
+    }
+
+    public static RfcRc LoadCryptoLibrary(string libraryPath, out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcLoadCryptoLibrary(libraryPath, out errorInfo);
+    }
+
     public static ConnectionHandle OpenConnection(IDictionary<string, string> connectionParams,
         out RfcErrorInfo errorInfo)
     {

--- a/src/YaNco.Core/Internal/Interopt.cs
+++ b/src/YaNco.Core/Internal/Interopt.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
 // ReSharper disable IdentifierTypo
 // ReSharper disable CommentTypo
+// ReSharper disable InconsistentNaming
 
 namespace Dbosoft.YaNco.Internal;
 
@@ -12,8 +16,28 @@ internal static class Interopt
     private const string SapNwRfcName = "sapnwrfc";
 
     [DllImport(SapNwRfcName)]
-    public static extern RfcRc RfcGetVersion(out uint majorVersion, out uint minorVersion, out uint patchLevel);
+    public static extern IntPtr RfcGetVersion(out uint majorVersion, out uint minorVersion, out uint patchLevel);
 
+    [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+    public static extern RfcRc RfcSetTraceDir(string traceDir, out RfcErrorInfo errorInfo);
+
+
+    [DllImport(SapNwRfcName)]
+    public static extern RfcRc RfcSetMaximumStoredTraceFiles(int numberOfFiles, out RfcErrorInfo errorInfo);
+
+
+    [DllImport(SapNwRfcName)]
+    public static extern RfcRc RfcSetCpicTraceLevel(uint traceLevel, out RfcErrorInfo errorInfo);
+
+
+    [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+    public static extern RfcRc RfcLoadCryptoLibrary(string pathToLibrary, out RfcErrorInfo errorInfo);
+
+    [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+    public static extern RfcRc RfcSetIniPath(string pathName, out RfcErrorInfo errorInfo);
+
+    [DllImport(SapNwRfcName)]
+    public static extern RfcRc RfcReloadIniFile(out RfcErrorInfo errorInfo);
 
     [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
     public static extern IntPtr RfcOpenConnection(RfcConnectionParameter[] connectionParams, uint paramCount, out RfcErrorInfo errorInfo);

--- a/src/YaNco.Core/Live/IOResult.cs
+++ b/src/YaNco.Core/Live/IOResult.cs
@@ -49,4 +49,19 @@ public static class IOResult
         logger.IfSome(l => l.LogTrace("received result value from rfc call", result));
         return result;
     }
+
+    public static Either<RfcError, TResult> ResultOrError<TResult>(
+        Option<ILogger> logger,
+        TResult result, RfcRc rc)
+    {
+        if (rc != RfcRc.RFC_OK)
+        {
+            logger.IfSome(l => l.LogDebug("received error from rfc call", 
+                rc));
+            return RfcError.Error(rc);
+        }
+
+        logger.IfSome(l => l.LogTrace("received result value from rfc call", result));
+        return result;
+    }
 }

--- a/src/YaNco.Core/Live/LiveSAPRfcLibraryIO.cs
+++ b/src/YaNco.Core/Live/LiveSAPRfcLibraryIO.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Dbosoft.YaNco.Internal;
+using Dbosoft.YaNco.Traits;
+using LanguageExt;
+
+namespace Dbosoft.YaNco.Live;
+
+public readonly struct LiveSAPRfcLibraryIO : SAPRfcLibraryIO
+{
+    private readonly Option<ILogger> _logger;
+
+    public LiveSAPRfcLibraryIO(Option<ILogger> logger)
+    {
+        _logger = logger;
+    }
+
+    public Either<RfcError, Version> GetVersion()
+    {
+        return Prelude.Try(Api.GetVersion).ToEither(f => RfcError.New(f));
+
+    }
+
+    public Either<RfcError, Unit> SetTraceDirectory(string traceDirectory)
+    {
+        var rc = Api.SetTraceDirectory(traceDirectory, out var errorInfo);
+        return IOResult.ResultOrError(_logger, Unit.Default, rc, errorInfo);
+    }
+
+    public Either<RfcError, Unit> SetMaximumTraceFiles(int traceFiles)
+    {
+        var rc = Api.SetMaximumTraceFiles(traceFiles, out var errorInfo);
+        return IOResult.ResultOrError(_logger, Unit.Default, rc, errorInfo);
+    }
+
+    public Either<RfcError, Unit> SetCpicTraceLevel(int traceLevel)
+    {
+        var rc = Api.SetCpicTraceLevel(traceLevel, out var errorInfo);
+        return IOResult.ResultOrError(_logger, Unit.Default, rc, errorInfo);
+    }
+
+    public Either<RfcError, Unit> LoadCryptoLibrary(string libraryPath)
+    {
+        var rc = Api.LoadCryptoLibrary(libraryPath, out var errorInfo);
+        return IOResult.ResultOrError(_logger, Unit.Default, rc, errorInfo);
+    }
+
+    public Either<RfcError, Unit> SetIniDirectory(string iniDirectory)
+    {
+        var rc = Api.SetIniDirectory(iniDirectory, out var errorInfo);
+        return IOResult.ResultOrError(_logger, Unit.Default, rc, errorInfo);
+    }
+
+    public Either<RfcError, Unit> ReloadRfcIni()
+    {
+        var rc = Api.ReloadIniFile(out var errorInfo);
+        return IOResult.ResultOrError(_logger, Unit.Default, rc, errorInfo);
+    }
+
+}

--- a/src/YaNco.Core/Live/LiveSAPRfcServerIO.cs
+++ b/src/YaNco.Core/Live/LiveSAPRfcServerIO.cs
@@ -6,7 +6,6 @@ using LanguageExt;
 
 namespace Dbosoft.YaNco.Live;
 
-
 public readonly struct LiveSAPRfcServerIO : SAPRfcServerIO
 {
     private readonly Option<ILogger> _logger;

--- a/src/YaNco.Core/Live/SAPRfcRuntime.cs
+++ b/src/YaNco.Core/Live/SAPRfcRuntime.cs
@@ -12,7 +12,8 @@ namespace Dbosoft.YaNco.Live;
 /// </summary>
 public readonly struct SAPRfcRuntime
         
-    : HasSAPRfc<SAPRfcRuntime>,
+    : HasSAPRfc<SAPRfcRuntime>, 
+      HasSAPRfcLibrary<SAPRfcRuntime>,
       HasSAPRfcServer<SAPRfcRuntime>,
       HasCancel<SAPRfcRuntime>
 
@@ -84,6 +85,7 @@ public readonly struct SAPRfcRuntime
     private SAPRfcFunctionIO FunctionIO => Env.Settings.RfcFunctionIO ?? new LiveSAPRfcFunctionIO(Logger, DataIO);
     private SAPRfcConnectionIO ConnectionIO => Env.Settings.RfcConnectionIO ?? new LiveSAPRfcConnectionIO(Logger);
     private SAPRfcServerIO ServerIO => Env.Settings.RfcServerIO ?? new LiveSAPRfcServerIO(Logger);
+    private SAPRfcLibraryIO LibraryIO => Env.Settings.RfcLibraryIO ?? new LiveSAPRfcLibraryIO(Logger);
 
 
     public Eff<SAPRfcRuntime, Option<ILogger>> RfcLoggerEff => Prelude.Eff<SAPRfcRuntime, Option<ILogger>>(rt => rt.Logger);
@@ -102,4 +104,7 @@ public readonly struct SAPRfcRuntime
 
     public Eff<SAPRfcRuntime, IFieldMapper> FieldMapperEff => Prelude.Eff < SAPRfcRuntime, IFieldMapper>(
                rt => rt.Env.Settings.FieldMapper);
+
+    public Eff<SAPRfcRuntime, SAPRfcLibraryIO> RfcLibraryEff => Prelude.Eff<SAPRfcRuntime, SAPRfcLibraryIO>(
+               rt => rt.LibraryIO);
 }

--- a/src/YaNco.Core/Test/TestSAPRfcRuntime.cs
+++ b/src/YaNco.Core/Test/TestSAPRfcRuntime.cs
@@ -11,6 +11,7 @@ public readonly struct TestSAPRfcRuntime
         
     : HasSAPRfcServer<TestSAPRfcRuntime>, 
         HasSAPRfc<TestSAPRfcRuntime>, 
+        HasSAPRfcLibrary<TestSAPRfcRuntime>,
         HasCancel<TestSAPRfcRuntime>
 {
     private readonly SAPRfcRuntimeEnv<SAPRfcRuntimeSettings> _env;
@@ -84,4 +85,7 @@ public readonly struct TestSAPRfcRuntime
 
     public Eff<TestSAPRfcRuntime, IFieldMapper> FieldMapperEff => Prelude.Eff<TestSAPRfcRuntime, IFieldMapper>(
                rt => rt.Env.Settings.FieldMapper);
+
+    public Eff<TestSAPRfcRuntime, SAPRfcLibraryIO> RfcLibraryEff => Prelude.Eff<TestSAPRfcRuntime, SAPRfcLibraryIO>(
+               rt => rt.Env.Settings.RfcLibraryIO);
 }

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -123,6 +123,18 @@ internal class Program
 
         // functional style Tests:
 
+        // library tests
+        var libVersion = SAPRfcRuntime.Default.RfcLibraryEff.Bind(io =>
+            {
+                return (
+                    from _ in io.SetTraceDirectory(AppDomain.CurrentDomain.BaseDirectory)
+                    from version in io.GetVersion()
+                    select version).ToEff(l => l);
+            })
+            .Run(SAPRfcRuntime.Default);
+
+        Console.WriteLine("Library Version: " + libVersion);
+
         var connectionEffect = new ConnectionBuilder(settings)
             .ConfigureRuntime(c=>c.WithLogger(new SimpleConsoleLogger()))
             .BuildIO();


### PR DESCRIPTION
new Trait `HasSAPRfcLibrary<RT>` with RfcLibraryIO containing methods:

    Either<RfcError, System.Version> GetVersion();
    Either<RfcError, Unit> SetTraceDirectory(string traceDirectory);
    Either<RfcError, Unit> SetMaximumTraceFiles(int traceFiles);
    Either<RfcError, Unit> SetCpicTraceLevel(int traceLevel);

    Either<RfcError, Unit> LoadCryptoLibrary(string libraryPath);
    Either<RfcError, Unit> SetIniDirectory(string iniDirectory);
    Either<RfcError, Unit> ReloadRfcIni();

