### PR TITLE
Downport optional parameter fix to 4.3

### DIFF
--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -130,7 +130,7 @@ namespace Dbosoft.YaNco.Internal
                 Name = parameterDescription.Name,
                 Type = parameterDescription.Type,
                 Direction = parameterDescription.Direction,
-                Optional = parameterDescription.Optional ? 'X' : '\0',
+                Optional = parameterDescription.Optional ? '1' : '0',
                 Decimals = parameterDescription.Decimals,
                 NucLength = parameterDescription.NucLength,
                 UcLength = parameterDescription.UcLength,
@@ -158,7 +158,7 @@ namespace Dbosoft.YaNco.Internal
         {
             var rc = Interopt.RfcGetParameterDescByName(descriptionHandle.Ptr, name.ToUpperInvariant(), out var parameterDescr, out errorInfo);
             parameterInfo = new RfcParameterInfo(
-                parameterDescr.Name, parameterDescr.Type, parameterDescr.Direction, parameterDescr.NucLength, parameterDescr.UcLength, parameterDescr.Decimals, parameterDescr.DefaultValue, parameterDescr.ParameterText, parameterDescr.Optional == 'X');
+                parameterDescr.Name, parameterDescr.Type, parameterDescr.Direction, parameterDescr.NucLength, parameterDescr.UcLength, parameterDescr.Decimals, parameterDescr.DefaultValue, parameterDescr.ParameterText, parameterDescr.Optional == 1);
             return rc;
 
         }
@@ -168,7 +168,7 @@ namespace Dbosoft.YaNco.Internal
         {
             var rc = Interopt.RfcGetParameterDescByIndex(descriptionHandle.Ptr, (uint)index, out var parameterDescr, out errorInfo);
             parameterInfo = new RfcParameterInfo(
-                parameterDescr.Name, parameterDescr.Type, parameterDescr.Direction, parameterDescr.NucLength, parameterDescr.UcLength, parameterDescr.Decimals, parameterDescr.DefaultValue, parameterDescr.ParameterText, parameterDescr.Optional == 'X');
+                parameterDescr.Name, parameterDescr.Type, parameterDescr.Direction, parameterDescr.NucLength, parameterDescr.UcLength, parameterDescr.Decimals, parameterDescr.DefaultValue, parameterDescr.ParameterText, parameterDescr.Optional == 1);
             return rc;
 
         }


### PR DESCRIPTION
Downport of #315 to 4.3 support branch, 

Fixed mapping of the optional parameters when getting the parameters description from SAP SDK

see #315