### PR TITLE
Allow direct access to connection and datacontainer handles

### DIFF
--- a/src/YaNco.Abstractions/IConnection.cs
+++ b/src/YaNco.Abstractions/IConnection.cs
@@ -120,4 +120,13 @@ public interface IConnection : IDisposable
     IRfcRuntime RfcRuntime { get;  }
 
     IHasEnvRuntimeSettings ConnectionRuntime { get; }
+
+    /// <summary>
+    /// Direct access to the connection handle.
+    /// </summary>
+    /// <remarks>
+    /// Use this property only if you would like to call runtime api methods that are not covered by the <see cref="IConnection"/> interface.
+    /// When operating on the handle, you have to make sure that the connection is accessed in a thread safe manner.
+    /// </remarks>
+    IConnectionHandle Handle { get; }
 }

--- a/src/YaNco.Abstractions/IDataContainer.cs
+++ b/src/YaNco.Abstractions/IDataContainer.cs
@@ -14,4 +14,12 @@ public interface IDataContainer : IDisposable
     Either<RfcError, IStructure> GetStructure(string name);
     Either<RfcError, ITable> GetTable(string name);
     Either<RfcError, ITypeDescriptionHandle> GetTypeDescription();
+
+    /// <summary>
+    /// Direct access to the container handle.
+    /// </summary>
+    /// <remarks>
+    /// Use this property only if you would like to call runtime api methods that are not covered by the <see cref="IDataContainer"/> interface.
+    /// </remarks>
+    IDataContainerHandle Handle { get; }
 }

--- a/src/YaNco.Abstractions/IFunction.cs
+++ b/src/YaNco.Abstractions/IFunction.cs
@@ -4,6 +4,12 @@ namespace Dbosoft.YaNco;
 
 public interface IFunction : IDataContainer
 {
+    /// <summary>
+    /// Direct access to the function handle.
+    /// </summary>
+    /// <remarks>
+    /// Use this property only if you would like to call runtime api methods that are not covered by the <see cref="IFunction"/> interface.
+    /// </remarks>
     [Browsable(false)]
-    IFunctionHandle Handle { get; }   
+    new IFunctionHandle Handle { get; }   
 }

--- a/src/YaNco.Core/Connection.cs
+++ b/src/YaNco.Core/Connection.cs
@@ -28,6 +28,7 @@ public class Connection<RT> : IConnection
         _runtime.Env.Source, _runtime.Env.Settings));
 
     public IHasEnvRuntimeSettings ConnectionRuntime => _runtime;
+    public IConnectionHandle Handle => _connectionHandle;
 
     public Connection(
         RT runtime,

--- a/src/YaNco.Core/ConnectionPlaceholder.cs
+++ b/src/YaNco.Core/ConnectionPlaceholder.cs
@@ -85,5 +85,5 @@ internal class ConnectionPlaceholder : IConnection
     [Obsolete(Deprecations.RfcRuntime)]
     public IRfcRuntime RfcRuntime { get; } = new RfcRuntime(SAPRfcRuntime.Default);
     public IHasEnvRuntimeSettings ConnectionRuntime { get; } = SAPRfcRuntime.Default;
-
+    public IConnectionHandle Handle { get; }
 }

--- a/src/YaNco.Core/DataContainer.cs
+++ b/src/YaNco.Core/DataContainer.cs
@@ -53,6 +53,8 @@ internal abstract class DataContainer : IDataContainer
         return IO.GetTypeDescription(_handle);
     }
 
+    public IDataContainerHandle Handle => _handle;
+
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -173,6 +173,20 @@ internal class Program
         result = await withFieldMapping.Run(SAPRfcRuntime.Default);
 
         Console.WriteLine("call_getFullName_with_abapValue: " + result);
+
+        var paramsCall = useConnection(connectionEffect, connection =>
+            from getUserFunction in connection.CreateFunction("BAPI_USER_GET_DETAIL").ToAff(l=>l)
+            from rt in Prelude.runtime<SAPRfcRuntime>()
+            from functionEff in rt.RfcFunctionsEff
+            from dataEff in rt.RfcDataEff
+            from funcDescription in functionEff.GetFunctionDescription(getUserFunction.Handle).ToEff(l => l)
+            from userParam in functionEff.GetFunctionParameterDescription(funcDescription, "USERNAME").ToEff(l=>l)
+            from paramsParam in functionEff.GetFunctionParameterDescription(funcDescription, "PARAMETER").ToEff(l => l)
+            select (UserName: userParam, Params: paramsParam));
+
+        var paramsResult = await paramsCall.Run(SAPRfcRuntime.Default);
+        Console.WriteLine("call_getParams_with_connection: " + paramsResult);
+
         return;
 
         static RfcError Callback(string command)


### PR DESCRIPTION
For calling APIs directly from the functional interfaces handles have to be used for connections and data containers. These are now also exposed on the default interfaces.

This PR also adds a test for direct access of function parameters out of a function call context. 