### PR TITLE
RFC error may result in bottom state

### DIFF
--- a/YaNco.sln.DotSettings
+++ b/YaNco.sln.DotSettings
@@ -3,6 +3,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RT/@EntryIndexedValue">RT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SAP/@EntryIndexedValue">SAP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb_AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AA_BB" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=2c62818f_002D621b_002D4425_002Dadc9_002D78611099bfcb/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Any" AccessRightKinds="Any" Description="Type parameters"&gt;&lt;ElementKinds&gt;&lt;Kind Name="TYPE_PARAMETER" /&gt;&lt;/ElementKinds&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" WarnAboutPrefixesAndSuffixes="False" Prefix="T" Suffix="" Style="AaBb_AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AA_BB" /&gt;&lt;/Policy&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EPredefinedNamingRulesToUserRulesUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Abap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BAPI/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BAPIRET/@EntryIndexedValue">True</s:Boolean>

--- a/samples/net6.0/ExportMATMAS/ExportMATMAS.csproj
+++ b/samples/net6.0/ExportMATMAS/ExportMATMAS.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LanguageExt.Sys" Version="4.4.3" />
+        <PackageReference Include="LanguageExt.Sys" Version="4.4.9" />
         <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/YaNco.Core/RuntimeToEitherExtensions.cs
+++ b/src/YaNco.Core/RuntimeToEitherExtensions.cs
@@ -11,7 +11,7 @@ internal static class RuntimeToEitherExtensions
     public static Either<RfcError, T> ToEither<T,RT>(this Eff<RT, T> eff, RT runtime)
        where RT : struct
     {
-        return eff.Run(runtime).Map(fin => fin.ToEither().ToRfcError()).FirstOrDefault();
+        return eff.Run(runtime).ToEither().ToRfcError();
 
     }
     public static EitherAsync<RfcError, T> ToEither<RT,T>(this Aff<RT, T> aff, RT runtime)

--- a/src/YaNco.Primitives/YaNco.Primitives.csproj
+++ b/src/YaNco.Primitives/YaNco.Primitives.csproj
@@ -24,6 +24,7 @@ This package contains primitive type definitions.</Description>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+    <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/SAPSystemTests/SAPSystemTests.csproj
+++ b/test/SAPSystemTests/SAPSystemTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PackageOutputPath>..\..\build-tools</PackageOutputPath>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>D662BD92-26B8-421C-9C14-33E009457A3B</UserSecretsId>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
A RFC error may cause a bottom state in connection effect. The ToEither method used to map runtime effect to Either is invalid in fixed in LanguageExt 4.4.9