### PR TITLE
added a sample implementation for pooling

### DIFF
--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -187,6 +187,9 @@ internal class Program
         var paramsResult = await paramsCall.Run(SAPRfcRuntime.Default);
         Console.WriteLine("call_getParams_with_connection: " + paramsResult);
 
+        // Agent Pool Test (from antwort_wytrickus.md sample)
+        await RunAgentPoolTest(connectionFunc);
+
         return;
 
         static RfcError Callback(string command)
@@ -581,6 +584,47 @@ internal class Program
         watch.Stop();
         return watch.ElapsedMilliseconds;
 
+    }
+
+    private static async Task RunAgentPoolTest(Func<EitherAsync<RfcError, IConnection>> connectionFunc)
+    {
+        Console.WriteLine("*** BEGIN Agent Pool Test ***");
+        const int poolSize = 3;
+        const int concurrentCalls = 10;
+
+        using var pool = new SapAgentPool(connectionFunc, poolSize);
+
+        // Run multiple concurrent calls through the pool
+        var tasks = Enumerable.Range(0, concurrentCalls)
+            .Select(i => pool.Execute(ctx =>
+                ctx.CallFunction("BAPI_USER_GET_DETAIL",
+                    Input: f => f.SetField("USERNAME", "SAP*"),
+                    Output: f => f.GetField<string>("USERNAME"))
+                    .ToEither()))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        var successCount = results.Count(r => r.IsRight);
+        var failCount = results.Count(r => r.IsLeft);
+
+        Console.WriteLine($"Agent Pool: {concurrentCalls} calls, pool size {poolSize}");
+        Console.WriteLine($"  Successes: {successCount}, Failures: {failCount}");
+
+        foreach (var r in results.Where(r => r.IsLeft))
+            r.IfLeft(l => Console.WriteLine($"  Error: {l.Message}"));
+
+        if (successCount == concurrentCalls)
+        {
+            var allSame = results.All(r => r.Match(x => x == "SAP*", _ => false));
+            Console.WriteLine(allSame ? "Test succeed" : "Test failed (results differ)");
+        }
+        else
+        {
+            Console.WriteLine("Test failed");
+        }
+
+        Console.WriteLine("*** END Agent Pool Test ***");
     }
 
     private static Either<RfcError, IFunction> SetRows(Either<RfcError, IFunction> func, in int rows)

--- a/test/SAPSystemTests/SapAgentPool.cs
+++ b/test/SAPSystemTests/SapAgentPool.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dbosoft.Functional;
+using Dbosoft.YaNco;
+using LanguageExt;
+
+namespace SAPSystemTests;
+
+/// <summary>
+/// A pool of RFC agents that limits the number of concurrent SAP RFC connections.
+/// Each agent holds its own <see cref="RfcContext"/> and processes calls sequentially
+/// via an internal queue. Incoming requests are distributed round-robin across agents.
+/// Broken connections are automatically replaced on the next request.
+/// An optional <c>maxPending</c> parameter limits the number of queued requests
+/// to provide backpressure to callers.
+/// </summary>
+public class SapAgentPool : IDisposable
+{
+    private readonly IAgent<Func<AgentState, Task>>[] _agents;
+    private readonly AgentState[] _states;
+    private readonly SemaphoreSlim _throttle;
+    private int _roundRobin;
+    private int _pending;
+
+    public SapAgentPool(Func<EitherAsync<RfcError, IConnection>> connFunc,
+        int poolSize = 3, int maxPending = 0)
+    {
+        _throttle = maxPending > 0 ? new SemaphoreSlim(maxPending) : null;
+        _states = new AgentState[poolSize];
+        _agents = Enumerable.Range(0, poolSize)
+            .Select(i =>
+            {
+                var state = new AgentState(connFunc);
+                _states[i] = state;
+                return Agent.Start<AgentState, Func<AgentState, Task>>(
+                    initialState: state,
+                    process: async (s, fn) =>
+                    {
+                        await fn(s);
+                        return s;
+                    });
+            })
+            .ToArray();
+    }
+
+    public async Task<Either<RfcError, T>> Execute<T>(
+        Func<RfcContext, Task<Either<RfcError, T>>> fn)
+    {
+        if (_throttle != null && !await _throttle.WaitAsync(TimeSpan.FromSeconds(30)))
+            return new RfcError(new RfcErrorInfo(
+                RfcRc.RFC_EXTERNAL_FAILURE,
+                RfcErrorGroup.EXTERNAL_RUNTIME_FAILURE,
+                "", "Agent pool saturated", "", "E", "", "", "", "", ""));
+
+        var tcs = new TaskCompletionSource<Either<RfcError, T>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Interlocked.Increment(ref _pending);
+        var idx = (Interlocked.Increment(ref _roundRobin) & 0x7FFFFFFF) % _agents.Length;
+
+        _agents[idx].Tell(async state =>
+        {
+            try
+            {
+                var result = await fn(state.Context);
+                result.IfLeft(err =>
+                {
+                    if (IsConnectionError(err))
+                        state.RecreateContext();
+                });
+                tcs.SetResult(result);
+            }
+            catch (Exception ex)
+            {
+                state.RecreateContext();
+                tcs.SetResult(new RfcError(new RfcErrorInfo(
+                    RfcRc.RFC_EXTERNAL_FAILURE,
+                    RfcErrorGroup.EXTERNAL_RUNTIME_FAILURE,
+                    "", ex.Message, "", "E", "", "", "", "", "")));
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _pending);
+                _throttle?.Release();
+            }
+        });
+
+        return await tcs.Task;
+    }
+
+    private static bool IsConnectionError(RfcError err)
+    {
+        return err.Rc is RfcRc.RFC_COMMUNICATION_FAILURE
+            or RfcRc.RFC_CLOSED
+            or RfcRc.RFC_TIMEOUT
+            or RfcRc.RFC_INVALID_HANDLE;
+    }
+
+    public void Dispose()
+    {
+        var sw = Stopwatch.StartNew();
+        while (Volatile.Read(ref _pending) > 0 && sw.ElapsedMilliseconds < 5000)
+            Thread.Sleep(50);
+
+        foreach (var state in _states)
+            state.Dispose();
+
+        _throttle?.Dispose();
+    }
+
+    public class AgentState : IDisposable
+    {
+        private readonly Func<EitherAsync<RfcError, IConnection>> _connFunc;
+        public RfcContext Context { get; private set; }
+
+        public AgentState(Func<EitherAsync<RfcError, IConnection>> connFunc)
+        {
+            _connFunc = connFunc;
+            Context = new RfcContext(connFunc);
+        }
+
+        public void RecreateContext()
+        {
+            Context.Dispose();
+            Context = new RfcContext(_connFunc);
+        }
+
+        public void Dispose() => Context.Dispose();
+    }
+}


### PR DESCRIPTION
Added a solution for connection pooling based on a agent queue. 

This solution is limited when it comes to connection state management (no state reset), for a full implementation of pooling in the api we may have to add connection resets to the nwrfc api. 