### PR TITLE
Expose RfcResetServerContext on connection interface 

### DIFF
--- a/src/YaNco.Abstractions/IConnection.cs
+++ b/src/YaNco.Abstractions/IConnection.cs
@@ -107,6 +107,17 @@ public interface IConnection : IDisposable
     /// <returns>A <see cref="EitherAsync{RfcError,ConnectionAttributes}"/> with any rfc error as left state and the attributes as right state.</returns>
     EitherAsync<RfcError, ConnectionAttributes> GetAttributes();
 
+    /// <summary>
+    /// Resets the server context of the connection.
+    /// </summary>
+    /// <remarks>
+    /// SAP RFC connections are stateful by default. When a connection is reused for different logical units of work
+    /// (e.g. different users in a web application), the server-side context should be reset between uses to discard
+    /// any state left by a previous call. The connection itself stays open and can be used for further calls.
+    /// </remarks>
+    /// <returns>A <see cref="EitherAsync{RfcError,Unit}"/> with any rfc error as left state and Unit as right state.</returns>
+    EitherAsync<RfcError, Unit> ResetServerContext();
+
 
     /// <summary>
     /// Flag if connection is already disposed. 

--- a/src/YaNco.Abstractions/Traits/SAPRfcConnectionIO.cs
+++ b/src/YaNco.Abstractions/Traits/SAPRfcConnectionIO.cs
@@ -10,5 +10,6 @@ public interface SAPRfcConnectionIO
     Either<RfcError, Unit> CancelConnection(IConnectionHandle connectionHandle);
     Either<RfcError, bool> IsConnectionHandleValid(IConnectionHandle connectionHandle);
     Either<RfcError, ConnectionAttributes> GetConnectionAttributes(IConnectionHandle connectionHandle);
+    Either<RfcError, Unit> ResetServerContext(IConnectionHandle connectionHandle);
 
 }

--- a/src/YaNco.Core/Connection.cs
+++ b/src/YaNco.Core/Connection.cs
@@ -242,6 +242,14 @@ public class Connection<RT> : IConnection
             .ToEither(_runtime).ToAsync();
     }
 
+    /// <inheritdoc cref="ResetServerContext()"/>
+    public EitherAsync<RfcError, Unit> ResetServerContext()
+    {
+        return default(RT).RfcConnectionEff
+            .Bind(io => io.ResetServerContext(_connectionHandle).ToEff(l => l))
+            .ToEither(_runtime).ToAsync();
+    }
+
     private record AgentMessage;
 
     private record CreateStructureMessage(string StructureName) : AgentMessage

--- a/src/YaNco.Core/ConnectionPlaceholder.cs
+++ b/src/YaNco.Core/ConnectionPlaceholder.cs
@@ -80,6 +80,11 @@ internal class ConnectionPlaceholder : IConnection
         return ErrorResponse;
     }
 
+    public EitherAsync<RfcError, Unit> ResetServerContext()
+    {
+        return ErrorResponse;
+    }
+
     public bool Disposed { get; private set; }
 
     [Obsolete(Deprecations.RfcRuntime)]

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -245,6 +245,11 @@ public static class Api
         return rc;
     }
 
+    public static RfcRc ResetServerContext(ConnectionHandle connectionHandle, out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcResetServerContext(connectionHandle.Ptr, out errorInfo);
+    }
+
     public static RfcRc GetStructure(IDataContainerHandle dataContainer, string name,
         out StructureHandle structure, out RfcErrorInfo errorInfo)
     {

--- a/src/YaNco.Core/Internal/Interopt.cs
+++ b/src/YaNco.Core/Internal/Interopt.cs
@@ -66,6 +66,8 @@ internal static class Interopt
     [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
     public static extern RfcRc RfcGetServerContext(IntPtr rfcHandle, out RfcServerContext context, out RfcErrorInfo errorInfo);
 
+    [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+    public static extern RfcRc RfcResetServerContext(IntPtr rfcHandle, out RfcErrorInfo errorInfo);
 
     [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
     public static extern RfcRc RfcShutdownServer(IntPtr rfcHandle, uint timeout, out RfcErrorInfo errorInfo);

--- a/src/YaNco.Core/Live/LiveSAPRfcConnectionIO.cs
+++ b/src/YaNco.Core/Live/LiveSAPRfcConnectionIO.cs
@@ -59,4 +59,11 @@ public readonly struct LiveSAPRfcConnectionIO : SAPRfcConnectionIO
         var rc = Api.GetConnectionAttributes(connectionHandle as ConnectionHandle, out var attributes, out var errorInfo);
         return IOResult.ResultOrError(_logger, attributes, rc, errorInfo);
     }
+
+    public Either<RfcError, Unit> ResetServerContext(IConnectionHandle connectionHandle)
+    {
+        _logger.IfSome(l => l.LogTrace("resetting server context", new { connectionHandle }));
+        var rc = Api.ResetServerContext(connectionHandle as ConnectionHandle, out var errorInfo);
+        return IOResult.ResultOrError(_logger, Unit.Default, rc, errorInfo);
+    }
 }

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -303,4 +303,9 @@ public class RfcRuntime<RT> : IRfcRuntime
         return _runtime.RfcConnectionEff.Bind(io => io.GetConnectionAttributes(connectionHandle).ToEff(l => l)).ToEither(_runtime);
     }
 
+    public Either<RfcError, Unit> ResetServerContext(IConnectionHandle connectionHandle)
+    {
+        return _runtime.RfcConnectionEff.Bind(io => io.ResetServerContext(connectionHandle).ToEff(l => l)).ToEither(_runtime);
+    }
+
 }

--- a/src/YaNco.Core/SAPRfc.cs
+++ b/src/YaNco.Core/SAPRfc.cs
@@ -220,7 +220,7 @@ public static class SAPRfc<RT> where RT : struct, HasSAPRfc<RT>, HasCancel<RT>
     }
 
     /// <summary>
-    /// Rollback of current SAP transaction in backend. 
+    /// Rollback of current SAP transaction in backend.
     /// </summary>
     /// <returns>A <see cref="EitherAsync{RfcError,Unit}"/> with any rfc error as left state and <seealso cref="Unit"/> as right state.</returns>
     public static Aff<RT, Unit> rollback(IConnection connection)
@@ -229,6 +229,16 @@ public static class SAPRfc<RT> where RT : struct, HasSAPRfc<RT>, HasCancel<RT>
                from _ in connection.Rollback(ct).ToAff(l => l)
                select Unit.Default;
 
+    }
+
+    /// <summary>
+    /// Resets the server context of the connection. See <see cref="IConnection.ResetServerContext"/> for details.
+    /// </summary>
+    /// <returns>A <see cref="Aff{RT,Unit}"/> with any rfc error as left state and <seealso cref="Unit"/> as right state.</returns>
+    public static Aff<RT, Unit> resetServerContext(IConnection connection)
+    {
+        return from _ in connection.ResetServerContext().ToAff(l => l)
+               select Unit.Default;
     }
     
     /// <summary>

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -208,8 +208,25 @@ internal class Program
         await RunIntegrationTest02(context);
         await RunIntegrationTest03(context);
         await RunCallbackTest(context);
+        await RunResetServerContextTest(context);
 
         Console.WriteLine("*** END OF Integration Tests ***");
+    }
+
+    private static async Task RunResetServerContextTest(IRfcContext context)
+    {
+        Console.WriteLine("Integration Tests 05 (reset server context)");
+
+        var result = await (
+            from connection in context.GetConnection()
+            from _1 in context.Ping()
+            from _2 in connection.ResetServerContext()
+            from _3 in context.Ping()
+            select Unit.Default).ToEither();
+
+        result.Match(
+            _ => Console.WriteLine("Test succeed"),
+            l => Console.WriteLine("Reset server context test failed: " + l.Message));
     }
     private static async Task RunIntegrationTest01(IRfcContext context)
     {

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -208,8 +208,41 @@ internal class Program
         await RunIntegrationTest02(context);
         await RunIntegrationTest03(context);
         await RunCallbackTest(context);
+        await RunResetServerContextTest(context);
 
         Console.WriteLine("*** END OF Integration Tests ***");
+    }
+
+    private static async Task RunResetServerContextTest(IRfcContext context)
+    {
+        Console.WriteLine("Integration Tests 05 (reset server context clears session state)");
+
+        var value = RandomString(40);
+
+        var result = await (
+            from _set in context.CallFunctionOneWay("ZYANCO_IT_5",
+                f => f.SetField("IV_IN", value))
+            from before in context.CallFunction("ZYANCO_IT_6",
+                Input: f => f,
+                Output: f => f.GetField<string>("EV_OUT"))
+            from connection in context.GetConnection()
+            from _reset in connection.ResetServerContext()
+            from after in context.CallFunction("ZYANCO_IT_6",
+                Input: f => f,
+                Output: f => f.GetField<string>("EV_OUT"))
+            select (Before: before, After: after)).ToEither();
+
+        result.Match(
+            ok =>
+            {
+                if (ok.Before != value)
+                    Console.WriteLine($"Test failed: before reset expected '{value}', got '{ok.Before}'");
+                else if (!string.IsNullOrEmpty(ok.After?.TrimEnd()))
+                    Console.WriteLine($"Test failed: after reset expected empty, got '{ok.After}'");
+                else
+                    Console.WriteLine("Test succeed");
+            },
+            l => Console.WriteLine("Reset server context test error: " + l.Message));
     }
     private static async Task RunIntegrationTest01(IRfcContext context)
     {
@@ -594,18 +627,13 @@ internal class Program
 
         using var pool = new SapAgentPool(connectionFunc, poolSize);
 
-        // Run multiple concurrent calls through the pool. Each pooled task resets
-        // the server context first so any state left by a previous logical unit of
-        // work on the same connection is discarded (the use case ResetServerContext
-        // is designed for: reusing a stateful connection across users/requests).
+        // Run multiple concurrent calls through the pool
         var tasks = Enumerable.Range(0, concurrentCalls)
             .Select(i => pool.Execute(ctx =>
-                (from connection in ctx.GetConnection()
-                 from _ in connection.ResetServerContext()
-                 from userName in ctx.CallFunction("BAPI_USER_GET_DETAIL",
-                     Input: f => f.SetField("USERNAME", "SAP*"),
-                     Output: f => f.GetField<string>("USERNAME"))
-                 select userName).ToEither()))
+                ctx.CallFunction("BAPI_USER_GET_DETAIL",
+                    Input: f => f.SetField("USERNAME", "SAP*"),
+                    Output: f => f.GetField<string>("USERNAME"))
+                    .ToEither()))
             .ToArray();
 
         var results = await Task.WhenAll(tasks);

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -187,7 +187,7 @@ internal class Program
         var paramsResult = await paramsCall.Run(SAPRfcRuntime.Default);
         Console.WriteLine("call_getParams_with_connection: " + paramsResult);
 
-        // Agent Pool Test (from antwort_wytrickus.md sample)
+        // Agent Pool Test
         await RunAgentPoolTest(connectionFunc);
 
         return;
@@ -208,25 +208,8 @@ internal class Program
         await RunIntegrationTest02(context);
         await RunIntegrationTest03(context);
         await RunCallbackTest(context);
-        await RunResetServerContextTest(context);
 
         Console.WriteLine("*** END OF Integration Tests ***");
-    }
-
-    private static async Task RunResetServerContextTest(IRfcContext context)
-    {
-        Console.WriteLine("Integration Tests 05 (reset server context)");
-
-        var result = await (
-            from connection in context.GetConnection()
-            from _1 in context.Ping()
-            from _2 in connection.ResetServerContext()
-            from _3 in context.Ping()
-            select Unit.Default).ToEither();
-
-        result.Match(
-            _ => Console.WriteLine("Test succeed"),
-            l => Console.WriteLine("Reset server context test failed: " + l.Message));
     }
     private static async Task RunIntegrationTest01(IRfcContext context)
     {
@@ -611,13 +594,18 @@ internal class Program
 
         using var pool = new SapAgentPool(connectionFunc, poolSize);
 
-        // Run multiple concurrent calls through the pool
+        // Run multiple concurrent calls through the pool. Each pooled task resets
+        // the server context first so any state left by a previous logical unit of
+        // work on the same connection is discarded (the use case ResetServerContext
+        // is designed for: reusing a stateful connection across users/requests).
         var tasks = Enumerable.Range(0, concurrentCalls)
             .Select(i => pool.Execute(ctx =>
-                ctx.CallFunction("BAPI_USER_GET_DETAIL",
-                    Input: f => f.SetField("USERNAME", "SAP*"),
-                    Output: f => f.GetField<string>("USERNAME"))
-                    .ToEither()))
+                (from connection in ctx.GetConnection()
+                 from _ in connection.ResetServerContext()
+                 from userName in ctx.CallFunction("BAPI_USER_GET_DETAIL",
+                     Input: f => f.SetField("USERNAME", "SAP*"),
+                     Output: f => f.GetField<string>("USERNAME"))
+                 select userName).ToEither()))
             .ToArray();
 
         var results = await Task.WhenAll(tasks);

--- a/test/SAPSystemTests/SapAgentPool.cs
+++ b/test/SAPSystemTests/SapAgentPool.cs
@@ -66,11 +66,23 @@ public class SapAgentPool : IDisposable
             try
             {
                 var result = await fn(state.Context);
-                result.IfLeft(err =>
+                var needsRecreate = result.Match(_ => false, IsConnectionError);
+                if (needsRecreate)
                 {
-                    if (IsConnectionError(err))
-                        state.RecreateContext();
-                });
+                    state.RecreateContext();
+                }
+                else
+                {
+                    // Reset the server context before returning the connection to the
+                    // pool, so the next caller starts from a clean server-side state.
+                    var resetResult = await state.Context.GetConnection()
+                        .Bind(c => c.ResetServerContext()).ToEither();
+                    resetResult.IfLeft(err =>
+                    {
+                        if (IsConnectionError(err))
+                            state.RecreateContext();
+                    });
+                }
                 tcs.SetResult(result);
             }
             catch (Exception ex)


### PR DESCRIPTION
Expose RfcResetServerContext on connection interface and implement it in the core connection implementation. This allows to reset the server context of a connection, which is required for example when using the same connection for multiple users in a web application.