### PR TITLE
Add ClearTable extension (closes #348)

### DIFF
--- a/src/YaNco.Abstractions/ITable.cs
+++ b/src/YaNco.Abstractions/ITable.cs
@@ -7,4 +7,5 @@ public interface ITable : IDataContainer
 {
     IEnumerable<IStructure> Rows { get; }
     Either<RfcError, IStructure> AppendRow();
+    Either<RfcError, Unit> Clear();
 }

--- a/src/YaNco.Abstractions/Traits/SAPRfcTableIO.cs
+++ b/src/YaNco.Abstractions/Traits/SAPRfcTableIO.cs
@@ -15,5 +15,6 @@ public interface SAPRfcTableIO
     Either<RfcError, IStructureHandle> AppendTableRow(ITableHandle tableHandle);
     Either<RfcError, Unit> MoveToNextTableRow(ITableHandle tableHandle);
     Either<RfcError, Unit> MoveToFirstTableRow(ITableHandle tableHandle);
+    Either<RfcError, Unit> DeleteAllTableRows(ITableHandle tableHandle);
 
 }

--- a/src/YaNco.Core/FunctionalDataContainerExtensions.cs
+++ b/src/YaNco.Core/FunctionalDataContainerExtensions.cs
@@ -56,6 +56,25 @@ public static class FunctionalDataContainerExtensions
 
     }
 
+    /// <summary>
+    /// Removes all rows from the table with the given <paramref name="tableName"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this when a table parameter is both read and written in the same function call and you need to
+    /// discard the inbound rows before populating it with new data. Can be combined fluently with
+    /// <see cref="SetTable{TDataContainer,TInput,TResult}(Either{RfcError,TDataContainer},string,IEnumerable{TInput},Func{Either{RfcError,IStructure},TInput,Either{RfcError,TResult}})"/>.
+    /// </remarks>
+    /// <typeparam name="TDataContainer">Type of data container (a structure or function).</typeparam>
+    /// <param name="self">Data container lifted in <see cref="Either{RfcError,TDataContainer}"/> monad.</param>
+    /// <param name="tableName">Name of the table to clear.</param>
+    public static Either<RfcError, TDataContainer> ClearTable<TDataContainer>(
+        this Either<RfcError, TDataContainer> self, string tableName)
+        where TDataContainer : IDataContainer
+    {
+        return self.Bind(dc => dc.GetTable(tableName)
+            .Use(used => used.Bind(table => table.Clear()).Map(_ => dc)));
+    }
+
     public static Either<RfcError, IEnumerable<TResult>> MapStructure<TResult>(this Either<RfcError, ITable> eitherTable, Func<IStructure,Either<RfcError, TResult>> mapperFunc)
     {
         return eitherTable.Bind(table=> table.Rows.Map(mapperFunc).Traverse(l=>l));

--- a/src/YaNco.Core/Internal/Api.cs
+++ b/src/YaNco.Core/Internal/Api.cs
@@ -390,6 +390,12 @@ public static class Api
 
     }
 
+    public static RfcRc DeleteAllTableRows(TableHandle table, out RfcErrorInfo errorInfo)
+    {
+        return Interopt.RfcDeleteAllRows(table.Ptr, out errorInfo);
+
+    }
+
     public static RfcRc SetString(IDataContainerHandle containerHandle, string name, string value, out
         RfcErrorInfo errorInfo)
     {

--- a/src/YaNco.Core/Internal/Interopt.cs
+++ b/src/YaNco.Core/Internal/Interopt.cs
@@ -161,6 +161,9 @@ internal static class Interopt
     public static extern RfcRc RfcMoveToFirstRow(IntPtr tableHandle, out RfcErrorInfo errorInfo);
 
     [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
+    public static extern RfcRc RfcDeleteAllRows(IntPtr tableHandle, out RfcErrorInfo errorInfo);
+
+    [DllImport(SapNwRfcName, CharSet = CharSet.Unicode)]
     public static extern RfcRc RfcGetDate(IntPtr dataHandle, string name, char[] emptyDate,
         out RfcErrorInfo errorInfo);
 

--- a/src/YaNco.Core/Live/LiveSAPRfcDataIO.cs
+++ b/src/YaNco.Core/Live/LiveSAPRfcDataIO.cs
@@ -216,6 +216,14 @@ public readonly struct LiveSAPRfcDataIO : SAPRfcDataIO
 
     }
 
+    public Either<RfcError, Unit> DeleteAllTableRows(ITableHandle tableHandle)
+    {
+        Logger.IfSome(l => l.LogTrace("delete all table rows by table handle", tableHandle));
+        var rc = Api.DeleteAllTableRows(tableHandle as TableHandle, out var errorInfo);
+        return IOResult.ResultOrError(Logger, Unit.Default, rc, errorInfo);
+
+    }
+
     public Either<RfcError, ITypeDescriptionHandle> GetTypeDescription(IDataContainerHandle dataContainer)
     {
         Logger.IfSome(l => l.LogTrace("reading type description by container handle", dataContainer));

--- a/src/YaNco.Core/RfcRuntime.cs
+++ b/src/YaNco.Core/RfcRuntime.cs
@@ -72,6 +72,11 @@ public class RfcRuntime<RT> : IRfcRuntime
         return _runtime.RfcDataEff.Bind(io => io.MoveToFirstTableRow(tableHandle).ToEff(l => l)).ToEither(_runtime);
     }
 
+    public Either<RfcError, Unit> DeleteAllTableRows(ITableHandle tableHandle)
+    {
+        return _runtime.RfcDataEff.Bind(io => io.DeleteAllTableRows(tableHandle).ToEff(l => l)).ToEither(_runtime);
+    }
+
     public Either<RfcError, IRfcServerHandle> CreateServer(IDictionary<string, string> connectionParams)
     {
         return _runtime.RfcServerEff.Bind(io => io.CreateServer(connectionParams).ToEff(l => l)).ToEither(_runtime);

--- a/src/YaNco.Core/Table.cs
+++ b/src/YaNco.Core/Table.cs
@@ -34,4 +34,9 @@ internal class Table : TypeDescriptionDataContainer, ITable
         return IO.AppendTableRow(_handle).Map(sh => (IStructure) new Structure(sh, IO));
     }
 
+    public Either<RfcError, Unit> Clear()
+    {
+        return IO.DeleteAllTableRows(_handle);
+    }
+
 }

--- a/test/SAPSystemTests/Program.cs
+++ b/test/SAPSystemTests/Program.cs
@@ -209,6 +209,7 @@ internal class Program
         await RunIntegrationTest03(context);
         await RunCallbackTest(context);
         await RunResetServerContextTest(context);
+        await RunClearTableTest(context);
 
         Console.WriteLine("*** END OF Integration Tests ***");
     }
@@ -244,6 +245,51 @@ internal class Program
             },
             l => Console.WriteLine("Reset server context test error: " + l.Message));
     }
+    private static async Task RunClearTableTest(IRfcContext context)
+    {
+        Console.WriteLine("Integration Tests 06 (ClearTable removes pre-populated rows before invoke)");
+
+        var prePopulated = new[] { 0, 0 };
+        var inputRows = new[] { 0, 0, 0 };
+
+        // ZYANCO_IT_7 appends TAB_IN to TAB_OUT. Baseline keeps the rows we pre-populated in TAB_OUT,
+        // so we expect (prePopulated + inputRows) rows back.
+        var baseline = await context.CallFunction("ZYANCO_IT_7",
+            Input: f => f
+                .SetTable("TAB_OUT", prePopulated, (s, _) => s)
+                .SetTable("TAB_IN", inputRows, (s, _) => s),
+            Output: f => f.MapTable("TAB_OUT", s => s.ToDictionary())).ToEither();
+
+        // Same setup, but ClearTable wipes the pre-populated TAB_OUT rows before invoke.
+        // We expect only the rows the server appends from TAB_IN.
+        var cleared = await context.CallFunction("ZYANCO_IT_7",
+            Input: f => f
+                .SetTable("TAB_OUT", prePopulated, (s, _) => s)
+                .ClearTable("TAB_OUT")
+                .SetTable("TAB_IN", inputRows, (s, _) => s),
+            Output: f => f.MapTable("TAB_OUT", s => s.ToDictionary())).ToEither();
+
+        var expectedBaseline = prePopulated.Length + inputRows.Length;
+        var expectedCleared = inputRows.Length;
+
+        var failure = baseline.Match(
+            b => cleared.Match<string>(
+                c =>
+                {
+                    var baselineCount = b.Count();
+                    var clearedCount = c.Count();
+                    if (baselineCount != expectedBaseline)
+                        return $"baseline expected {expectedBaseline} rows (pre-populated + appended), got {baselineCount}";
+                    if (clearedCount != expectedCleared)
+                        return $"after ClearTable expected {expectedCleared} rows (appended only), got {clearedCount}";
+                    return string.Empty;
+                },
+                l => "ClearTable call error: " + l.Message),
+            l => "baseline call error: " + l.Message);
+
+        Console.WriteLine(failure.Length == 0 ? "Test succeed" : "Test failed: " + failure);
+    }
+
     private static async Task RunIntegrationTest01(IRfcContext context)
     {
         Console.WriteLine("Integration Tests 01 (I/O field)");


### PR DESCRIPTION
Adds a fluent `ClearTable(name)` extension that wraps the native `RfcDeleteAllRows` SAP NWRFC call, so a bidirectional `TABLES` parameter that carries stale rows from a prior context can be cleared inline before being re-populated in the same function call chain.

```csharp
Input: f => f
    .ClearTable("ITAB")
    .SetTable("ITAB", rows, (s, r) => s.SetField(...))
```

Plumbed through the same layers as `AppendTableRow` (`Interopt` → `Api` → `SAPRfcTableIO` trait → `LiveSAPRfcDataIO` → legacy `RfcRuntime` facade) and exposed on `ITable` as `Clear()`. Verified end-to-end against the SAP system with a new `ZYANCO_IT_7`-driven integration test that pre-populates the output table, clears it, then confirms only post-clear rows survive.

Closes #348